### PR TITLE
Feature/fix placeholders

### DIFF
--- a/LandLord-core/src/main/java/biz/princeps/landlord/placeholderapi/LLExpansion.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/placeholderapi/LLExpansion.java
@@ -66,7 +66,7 @@ public class LLExpansion extends PlaceholderExpansion {
         }
 
         try {
-            cache.get(player.getName() + "_" + placeholder, () ->
+            return cache.get(player.getName() + "_" + placeholder, () ->
                     parsePlaceholder(player, placeholder));
         } catch (ExecutionException e) {
             pl.getLogger().log(Level.SEVERE, "Could not parse placeholder: " + placeholder + " for " + player.getName() + "!", e);

--- a/LandLord-core/src/main/java/biz/princeps/landlord/placeholderapi/LLExpansion.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/placeholderapi/LLExpansion.java
@@ -80,7 +80,7 @@ public class LLExpansion extends PlaceholderExpansion {
                 return String.valueOf(wg.getRegionCount(player.getUniqueId()));
 
             case "claims":
-                final IPlayer iPlayer = pl.getPlayerManager().get(player.getUniqueId());
+                IPlayer iPlayer = pl.getPlayerManager().get(player.getUniqueId());
                 if (iPlayer == null) {
                     pl.getLogger().warning("A placeholder is trying to load %landlord_claims% before async loading of the " +
                             "player has finished! Use FinishedLoadingPlayerEvent!");
@@ -89,7 +89,7 @@ public class LLExpansion extends PlaceholderExpansion {
                 return String.valueOf(iPlayer.getClaims());
 
             case "remaining_claims":
-                final IPlayer iPlayer2 = pl.getPlayerManager().get(player.getUniqueId());
+                IPlayer iPlayer2 = pl.getPlayerManager().get(player.getUniqueId());
                 if (iPlayer2 == null) {
                     pl.getLogger().warning("A placeholder is trying to load %landlord_remainingClaims% before async loading of the " +
                             "player has finished! Use FinishedLoadingPlayerEvent!");
@@ -98,15 +98,15 @@ public class LLExpansion extends PlaceholderExpansion {
                 return String.valueOf(iPlayer2.getClaims() - wg.getRegionCount(player.getUniqueId()));
 
             case "current_land_owner":
-                final IOwnedLand region = wg.getRegion(player.getLocation());
+                IOwnedLand region = wg.getRegion(player.getLocation());
                 if (region != null && region.getOwner() != null) {
                     return region.getOwnersString();
                 }
                 return "∅";
 
             case "current_land_members":
-                final String members;
-                final IOwnedLand region2 = wg.getRegion(player.getLocation());
+                String members;
+                IOwnedLand region2 = wg.getRegion(player.getLocation());
                 if (region2 != null && !(members = region2.getMembersString()).isEmpty()) {
                     return members;
                 }
@@ -119,7 +119,7 @@ public class LLExpansion extends PlaceholderExpansion {
                 return String.valueOf(pl.getCostManager().calculateCost(player.getUniqueId()));
 
             case "current_land_refund":
-                final int regionCount = wg.getRegionCount(player.getUniqueId());
+                int regionCount = wg.getRegionCount(player.getUniqueId());
                 return String.valueOf(pl.getCostManager().calculateCost(regionCount - 1) * pl.getConfig().getDouble(
                         "Payback"));
 
@@ -127,8 +127,8 @@ public class LLExpansion extends PlaceholderExpansion {
                 return String.valueOf(getMaxClaimPermission(player));
 
             case "remaining_free_lands":
-                final int landCount = wg.getRegionCount(player.getUniqueId());
-                final int freeLands = pl.getConfig().getInt("Freelands");
+                int landCount = wg.getRegionCount(player.getUniqueId());
+                int freeLands = pl.getConfig().getInt("Freelands");
 
                 if (landCount <= freeLands) {
                     return String.valueOf((Math.min(getMaxClaimPermission(player), freeLands)) - landCount);

--- a/LandLord-core/src/main/java/biz/princeps/landlord/placeholderapi/LLExpansion.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/placeholderapi/LLExpansion.java
@@ -136,7 +136,7 @@ public class LLExpansion extends PlaceholderExpansion {
                 return "0";
 
             default:
-                return null;
+                return "";
         }
     }
 


### PR DESCRIPTION
Found two small but critical bugs in the placeholder expansion.

- One missing return statement, which caused that null was always returned instead of the cached or computed value
- Null was returned by the placeholder method which is not allowed to be returned by a CacheLoader