### PR TITLE
Feature/adjustments

### DIFF
--- a/.github/workflows/publish_to_nexus.yml
+++ b/.github/workflows/publish_to_nexus.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v2.3.1
         with:
           distribution: temurin
           java-version: 11

--- a/.github/workflows/publish_to_nexus.yml
+++ b/.github/workflows/publish_to_nexus.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2.3.1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
       - name: Build with Gradle
         run: ./gradlew --build-cache build
       - name: Test with Gradle

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,11 +11,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2.3.1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
       - name: Build with Gradle
         run: ./gradlew --build-cache build
       - name: Test with Gradle

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v2.3.1
         with:
           distribution: temurin
           java-version: 11

--- a/LandLord-api/src/main/java/biz/princeps/landlord/api/ILandLord.java
+++ b/LandLord-api/src/main/java/biz/princeps/landlord/api/ILandLord.java
@@ -2,11 +2,12 @@ package biz.princeps.landlord.api;
 
 import org.bukkit.Server;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.logging.Logger;
 
-public interface ILandLord {
+public interface ILandLord extends Plugin {
 
     /**
      * Adapter to JavaPlugin#getConfig
@@ -27,7 +28,9 @@ public interface ILandLord {
      * Useful for starting runnables.
      *
      * @return instance of JavaPlugin
+     * @deprecated {@link ILandLord is a plugin itself and will only return itself. Use the instance directly.}
      */
+    @Deprecated(forRemoval = true, since = "4.357")
     JavaPlugin getPlugin();
 
     /**

--- a/LandLord-api/src/main/java/biz/princeps/landlord/api/ILandLord.java
+++ b/LandLord-api/src/main/java/biz/princeps/landlord/api/ILandLord.java
@@ -3,25 +3,10 @@ package biz.princeps.landlord.api;
 import org.bukkit.Server;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.logging.Logger;
 
 public interface ILandLord extends Plugin {
-
-    /**
-     * Adapter to JavaPlugin#getConfig
-     *
-     * @return the config file
-     */
-    FileConfiguration getConfig();
-
-    /**
-     * Adapter to JavaPlugin#getConfig
-     *
-     * @return the config file
-     */
-    Logger getLogger();
 
     /**
      * Returns the instance of the JavaPlugin.
@@ -31,15 +16,7 @@ public interface ILandLord extends Plugin {
      * @deprecated {@link ILandLord is a plugin itself and will only return itself. Use the instance directly.}
      */
     @Deprecated(forRemoval = true, since = "4.357")
-    JavaPlugin getPlugin();
-
-    /**
-     * Returns the instance of the Server.
-     * Useful for accessing and modifying server data.
-     *
-     * @return instance of Server
-     */
-    Server getServer();
+    Plugin getPlugin();
 
 
     /**

--- a/LandLord-api/src/main/java/biz/princeps/landlord/api/ILandLord.java
+++ b/LandLord-api/src/main/java/biz/princeps/landlord/api/ILandLord.java
@@ -13,7 +13,7 @@ public interface ILandLord extends Plugin {
      * Useful for starting runnables.
      *
      * @return instance of JavaPlugin
-     * @deprecated {@link ILandLord is a plugin itself and will only return itself. Use the instance directly.}
+     * @deprecated {@link ILandLord} is a plugin itself and will only return itself. Use the instance directly.
      */
     @Deprecated(forRemoval = true, since = "4.357")
     Plugin getPlugin();

--- a/LandLord-core/build.gradle.kts
+++ b/LandLord-core/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
     api(project(":LandLord-api"))
     implementation("com.zaxxer:HikariCP:4.0.3")
     implementation("io.github.bananapuncher714:nbteditor:7.16.1")
-    implementation("de.eldoria:eldo-util:1.9.2-DEV")
+    implementation("de.eldoria:eldo-util:1.12.0-DEV")
     compileOnly("org.spigotmc:spigot-api:1.12.2-R0.1-SNAPSHOT")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7")
     compileOnly("me.clip:placeholderapi:2.10.9")

--- a/LandLord-core/src/main/java/biz/princeps/landlord/ALandLord.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/ALandLord.java
@@ -135,9 +135,7 @@ public abstract class ALandLord extends JavaPlugin implements ILandLord, Listene
         this.getPluginLoader().disablePlugin(this);
     }
 
-    /**
-     * @return the javaplugin instance
-     */
+    @Deprecated(forRemoval = true)
     @Override
     public JavaPlugin getPlugin() {
         return this;

--- a/LandLord-core/src/main/java/biz/princeps/landlord/ALandLord.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/ALandLord.java
@@ -137,7 +137,7 @@ public abstract class ALandLord extends JavaPlugin implements ILandLord, Listene
 
     @Deprecated(forRemoval = true)
     @Override
-    public JavaPlugin getPlugin() {
+    public Plugin getPlugin() {
         return this;
     }
 
@@ -229,7 +229,7 @@ public abstract class ALandLord extends JavaPlugin implements ILandLord, Listene
 
                 getLogger().warning(
                         "Found an invalid world name (" + world.getName() + ")! LandLord will not work in this " +
-                                "world!");
+                        "world!");
             }
         }
     }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/Landlordbase.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/Landlordbase.java
@@ -143,7 +143,7 @@ public class Landlordbase extends MainCommand {
                             tabReturn.add(subCommand.getName());
                         }
                     } else if (subCommand instanceof Shop || subCommand instanceof Claims
-                            || subCommand instanceof GiveClaims) {
+                               || subCommand instanceof GiveClaims) {
                         if (Options.enabled_shop()) {
                             tabReturn.add(subCommand.getName());
                         }
@@ -186,10 +186,10 @@ public class Landlordbase extends MainCommand {
                     }
 
                     if (subcmd instanceof Addfriend || subcmd instanceof AddfriendAll ||
-                            subcmd instanceof Unfriend || subcmd instanceof UnfriendAll) {
+                        subcmd instanceof Unfriend || subcmd instanceof UnfriendAll) {
                         for (Player onlinePlayer : plugin.getServer().getOnlinePlayers()) {
                             if (!onlinePlayer.getName().startsWith(args[1]) ||
-                                    (sender instanceof Player && !((Player) sender).canSee(onlinePlayer)))
+                                (sender instanceof Player && !((Player) sender).canSee(onlinePlayer)))
                                 continue;
 
                             tabReturn.add(onlinePlayer.getName());
@@ -198,8 +198,8 @@ public class Landlordbase extends MainCommand {
                     }
 
                     if (subcmd instanceof MultiClaim || subcmd instanceof MultiUnclaim ||
-                            subcmd instanceof MultiAddfriend || subcmd instanceof MultiRemovefriend ||
-                            subcmd instanceof MultiListLands || subcmd instanceof MultiManage) {
+                        subcmd instanceof MultiAddfriend || subcmd instanceof MultiRemovefriend ||
+                        subcmd instanceof MultiListLands || subcmd instanceof MultiManage) {
                         for (MultiMode multiMode : MultiMode.values()) {
                             tabReturn.add(multiMode.name());
                         }
@@ -227,7 +227,7 @@ public class Landlordbase extends MainCommand {
                     if (subcmd instanceof MultiAddfriend || subcmd instanceof MultiRemovefriend) {
                         for (Player onlinePlayer : plugin.getServer().getOnlinePlayers()) {
                             if (!onlinePlayer.getName().startsWith(args[2]) ||
-                                    (sender instanceof Player && !((Player) sender).canSee(onlinePlayer)))
+                                (sender instanceof Player && !((Player) sender).canSee(onlinePlayer)))
                                 continue;
 
                             tabReturn.add(onlinePlayer.getName());
@@ -317,7 +317,7 @@ public class Landlordbase extends MainCommand {
         @Override
         public void onCommand(Properties properties, Arguments arguments) {
             String msg = plugin.getLangManager().getTag() + " &aLandLord version: &7%version%"
-                    .replace("%version%", plugin.getPlugin().getDescription().getVersion());
+                    .replace("%version%", plugin.getDescription().getVersion());
             properties.sendMessage(ChatColor.translateAlternateColorCodes('&', msg));
         }
     }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/AdminTeleport.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/AdminTeleport.java
@@ -53,7 +53,7 @@ public class AdminTeleport extends LandlordCommand {
                 // Success
                 Set<IOwnedLand> lands = plugin.getWGManager().getRegions(offline.getUuid());
                 if (lands.size() > 0) {
-                    MultiPagedGUI landGui = new MultiPagedGUI(plugin.getPlugin(), sender, 5,
+                    MultiPagedGUI landGui = new MultiPagedGUI(plugin, sender, 5,
                             lm.getRawString("Commands.AdminTp.guiHeader").replace("%player%", target));
 
                     for (IOwnedLand land : lands) {

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/ClearInactive.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/ClearInactive.java
@@ -78,7 +78,7 @@ public class ClearInactive extends LandlordCommand {
 
                 multiTaskManager.enqueueTask(new MultiClearInactiveTask(plugin, sender, playersToClear, minInactiveDays));
             }
-        }.runTaskAsynchronously(plugin.getPlugin());
+        }.runTaskAsynchronously(plugin);
     }
 
 }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/Debug.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/Debug.java
@@ -25,7 +25,7 @@ public class Debug extends SubCommand {
 
     @Override
     public void onCommand(Properties properties, Arguments arguments) {
-        DebugUtil.dispatchDebug(properties.getCommandSender(), plugin.getPlugin(), DebugSettings.DEFAULT);
+        DebugUtil.dispatchDebug(properties.getCommandSender(), plugin, DebugSettings.DEFAULT);
     }
 
 }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/Reload.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/Reload.java
@@ -24,7 +24,7 @@ public class Reload extends LandlordCommand {
         issuer.sendMessage(ChatColor.RED + "Reloading is not recommended! Before reporting any bugs, please restart your server.");
 
         plugin.getLangManager().reload();
-        plugin.getPlugin().reloadConfig();
+        plugin.reloadConfig();
         plugin.setupPrincepsLib();
         plugin.postloadPrincepsLib();
 

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/Update.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/Update.java
@@ -60,7 +60,7 @@ public class Update extends LandlordCommand {
                 }
                 issuer.sendMessage("§8[§c§l!§8] §fFinished updating lands!");
             }
-        }.runTaskAsynchronously(plugin.getPlugin());
+        }.runTaskAsynchronously(plugin);
     }
 
     /**
@@ -87,7 +87,7 @@ public class Update extends LandlordCommand {
 
                 sender.sendMessage("§8[§c§l!§8] §fFinished resetting lands!");
             }
-        }.runTaskAsynchronously(plugin.getPlugin());
+        }.runTaskAsynchronously(plugin);
     }
 
 }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/claiming/Claim.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/claiming/Claim.java
@@ -76,8 +76,8 @@ public class Claim extends LandlordCommand {
         // First check, if outer conditions (conditions that are related more to the buyer as individual)
         // Check for hardcap based on permissions
         if (!plugin.getConfig().getBoolean("CommandSettings.Claim.allowOverlap", false)
-                && !wg.canClaim(player, chunk)
-                && !(ol != null && (plugin.getPlayerManager().isInactiveSync(ol.getOwner()) || ol.getPrice() != -1))) {
+            && !wg.canClaim(player, chunk)
+            && !(ol != null && (plugin.getPlayerManager().isInactiveSync(ol.getOwner()) || ol.getPrice() != -1))) {
             lm.sendMessage(player, lm.getString(player, "Commands.Claim.notAllowed"));
             return;
         }
@@ -262,7 +262,7 @@ public class Claim extends LandlordCommand {
             public void run() {
                 plugin.getServer().getPluginManager().callEvent(postEvent);
             }
-        }.runTask(plugin.getPlugin());
+        }.runTask(plugin);
     }
 
 

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/Addfriend.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/Addfriend.java
@@ -74,7 +74,7 @@ public class Addfriend extends LandlordCommand {
                                     "FRIENDS", oldFriends, land.getMembersString());
                             plugin.getServer().getPluginManager().callEvent(landManageEvent);
                         }
-                    }.runTask(plugin.getPlugin());
+                    }.runTask(plugin);
 
                     lm.sendMessage(player, lm.getString(player, "Commands.Addfriend.success")
                             .replace("%players%", playerName));
@@ -86,7 +86,7 @@ public class Addfriend extends LandlordCommand {
                         public void run() {
                             plugin.getMapManager().updateAll();
                         }
-                    }.runTaskLater(plugin.getPlugin(), 60L);
+                    }.runTaskLater(plugin, 60L);
                 } else {
                     lm.sendMessage(player, lm.getString(player, "Commands.Addfriend.alreadyOwn"));
                 }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/AddfriendAll.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/AddfriendAll.java
@@ -71,7 +71,7 @@ public class AddfriendAll extends LandlordCommand {
                                                 "FRIENDS", oldfriends, ol.getMembersString());
                                         plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                     }
-                                }.runTask(plugin.getPlugin());
+                                }.runTask(plugin);
                             }
                         }
 
@@ -84,13 +84,12 @@ public class AddfriendAll extends LandlordCommand {
                             public void run() {
                                 plugin.getMapManager().updateAll();
                             }
-                        }.runTask(plugin.getPlugin());
+                        }.runTask(plugin);
                     }
-                }.runTaskAsynchronously(plugin.getPlugin());
+                }.runTaskAsynchronously(plugin);
             } else {
                 lm.sendMessage(player, lm.getString(player, "Commands.Addfriend.alreadyOwn"));
             }
         });
     }
 }
-

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/MultiAddfriend.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/MultiAddfriend.java
@@ -84,7 +84,7 @@ public class MultiAddfriend extends LandlordCommand {
                                                 "FRIENDS", oldfriends, ol.getMembersString());
                                         plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                     }
-                                }.runTask(plugin.getPlugin());
+                                }.runTask(plugin);
                             }
                         }
 
@@ -97,13 +97,12 @@ public class MultiAddfriend extends LandlordCommand {
                             public void run() {
                                 plugin.getMapManager().updateAll();
                             }
-                        }.runTask(plugin.getPlugin());
+                        }.runTask(plugin);
                     }
-                }.runTaskAsynchronously(plugin.getPlugin());
+                }.runTaskAsynchronously(plugin);
             } else {
                 lm.sendMessage(player, lm.getString(player, "Commands.MultiAddfriend.alreadyOwn"));
             }
         });
     }
 }
-

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/MultiRemovefriend.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/MultiRemovefriend.java
@@ -84,7 +84,7 @@ public class MultiRemovefriend extends LandlordCommand {
                                                 "FRIENDS", oldvalue, ol.getMembersString());
                                         plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                     }
-                                }.runTask(plugin.getPlugin());
+                                }.runTask(plugin);
                             }
                         }
 
@@ -98,16 +98,15 @@ public class MultiRemovefriend extends LandlordCommand {
                                 public void run() {
                                     plugin.getMapManager().updateAll();
                                 }
-                            }.runTask(plugin.getPlugin());
+                            }.runTask(plugin);
                         } else {
                             lm.sendMessage(player, lm.getString(player, "Commands.MultiUnfriend.noFriend")
                                     .replace("%player%", name));
                         }
                     }
-                }.runTaskAsynchronously(plugin.getPlugin());
+                }.runTaskAsynchronously(plugin);
             }
         });
     }
 
 }
-

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/Unfriend.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/Unfriend.java
@@ -83,7 +83,7 @@ public class Unfriend extends LandlordCommand {
                                     "FRIENDS", old, land.getMembersString());
                             plugin.getServer().getPluginManager().callEvent(landManageEvent);
                         }
-                    }.runTask(plugin.getPlugin());
+                    }.runTask(plugin);
 
                     lm.sendMessage(player, lm.getString(player, "Commands.Unfriend.success")
                             .replace("%players%", playerName));
@@ -95,7 +95,7 @@ public class Unfriend extends LandlordCommand {
                         public void run() {
                             plugin.getMapManager().updateAll();
                         }
-                    }.runTaskLater(plugin.getPlugin(), 60L);
+                    }.runTaskLater(plugin, 60L);
                 } else {
                     lm.sendMessage(player, lm.getString(player, "Commands.UnfriendAll.noFriend")
                             .replace("%player%", playerName));
@@ -104,4 +104,3 @@ public class Unfriend extends LandlordCommand {
         }
     }
 }
-

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/UnfriendAll.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/UnfriendAll.java
@@ -71,7 +71,7 @@ public class UnfriendAll extends LandlordCommand {
                                                 "FRIENDS", oldvalue, ol.getMembersString());
                                         plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                     }
-                                }.runTask(plugin.getPlugin());
+                                }.runTask(plugin);
                             }
                         }
 
@@ -85,15 +85,14 @@ public class UnfriendAll extends LandlordCommand {
                                 public void run() {
                                     plugin.getMapManager().updateAll();
                                 }
-                            }.runTask(plugin.getPlugin());
+                            }.runTask(plugin);
                         } else {
                             lm.sendMessage(player, lm.getString(player, "Commands.UnfriendAll.noFriend")
                                     .replace("%player%", name));
                         }
                     }
-                }.runTaskAsynchronously(plugin.getPlugin());
+                }.runTaskAsynchronously(plugin);
             }
         });
     }
 }
-

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/homes/Home.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/homes/Home.java
@@ -91,7 +91,7 @@ public class Home extends LandlordCommand {
                         public void run() {
                             teleport(home, player, targetPlayer);
                         }
-                    }.runTask(plugin.getPlugin());
+                    }.runTask(plugin);
                 }
             });
         }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Info.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Info.java
@@ -124,7 +124,7 @@ public class Info extends LandlordCommand {
                             plugin.getVaultManager().format(plugin.getCostManager().calculateCost(player.getUniqueId()))));
                     if (plugin.getConfig().getBoolean("Particles.info"))
                         land.highlightLand(player, Particle.valueOf(plugin.getConfig().getString("Particles.info" +
-                                ".inactive").toUpperCase()));
+                                                                                                 ".inactive").toUpperCase()));
                     return;
                 }
 
@@ -144,7 +144,7 @@ public class Info extends LandlordCommand {
         } else {
             // unclaimed
             if (!plugin.getConfig().getBoolean("CommandSettings.Claim.allowOverlap", false) &&
-                    !wg.canClaim(player, chunk)) {
+                !wg.canClaim(player, chunk)) {
                 lm.sendMessage(player, lm.getString(player, "Commands.Claim.notAllowed"));
                 return;
             } else {

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/ListLands.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/ListLands.java
@@ -99,7 +99,7 @@ public class ListLands extends LandlordCommand {
                 String mode = plugin.getConfig().getString("CommandSettings.ListLands.mode");
 
                 if (mode.equals("gui")) {
-                    MultiPagedGUI landGui = new MultiPagedGUI(plugin.getPlugin(), sender, 5,
+                    MultiPagedGUI landGui = new MultiPagedGUI(plugin, sender, 5,
                             plugin.getLangManager().getRawString("Commands.ListLands.gui.header")
                                     .replace("%player%", target.getName())) {
                         @Override
@@ -164,7 +164,7 @@ public class ListLands extends LandlordCommand {
                             public void run() {
                                 landGui.display();
                             }
-                        }.runTask(plugin.getPlugin());
+                        }.runTask(plugin);
                     }
                 } else {
                     // Chat based system
@@ -192,11 +192,11 @@ public class ListLands extends LandlordCommand {
                             public void run() {
                                 plugin.getUtilsManager().sendBasecomponent(sender, message.create());
                             }
-                        }.runTask(plugin.getPlugin());
+                        }.runTask(plugin);
                     }
                 }
             }
-        }.runTaskAsynchronously(plugin.getPlugin());
+        }.runTaskAsynchronously(plugin);
     }
 
     private String formatState(boolean bool) {

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Manage.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Manage.java
@@ -48,9 +48,9 @@ public class Manage extends LandlordCommand {
 
         // land manage
         if (args.length == 0 || (args.length == 1 && !args[0].equals("setgreet")
-                && !args[0].equals("setgreetall")
-                && !args[0].equals("setfarewell")
-                && !args[0].equals("setfarewellall"))) {
+                                 && !args[0].equals("setgreetall")
+                                 && !args[0].equals("setfarewell")
+                                 && !args[0].equals("setfarewellall"))) {
 
             IOwnedLand land;
             if (args.length == 0) {

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/MultiListLands.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/MultiListLands.java
@@ -106,7 +106,7 @@ public class MultiListLands extends LandlordCommand {
                 String confirmMode = plugin.getConfig().getString("CommandSettings.MultiListLands.mode");
 
                 if (confirmMode.equals("gui")) {
-                    MultiPagedGUI landGui = new MultiPagedGUI(plugin.getPlugin(), sender, 5,
+                    MultiPagedGUI landGui = new MultiPagedGUI(plugin, sender, 5,
                             plugin.getLangManager().getRawString("Commands.MultiListLands.gui.header")
                                     .replace("%player%", target.getName())) {
                         @Override
@@ -171,7 +171,7 @@ public class MultiListLands extends LandlordCommand {
                             public void run() {
                                 landGui.display();
                             }
-                        }.runTask(plugin.getPlugin());
+                        }.runTask(plugin);
                     }
                 } else {
                     // Chat based system
@@ -199,11 +199,11 @@ public class MultiListLands extends LandlordCommand {
                             public void run() {
                                 plugin.getUtilsManager().sendBasecomponent(sender, message.create());
                             }
-                        }.runTask(plugin.getPlugin());
+                        }.runTask(plugin);
                     }
                 }
             }
-        }.runTaskAsynchronously(plugin.getPlugin());
+        }.runTaskAsynchronously(plugin);
     }
 
     private String formatState(boolean bool) {

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Regenerate.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Regenerate.java
@@ -61,7 +61,7 @@ public class Regenerate extends LandlordCommand {
             String costString = (Options.isVaultEnabled() ? plugin.getVaultManager().format(cost) : "-1");
 
             IOwnedLand finalLand = land;
-            ConfirmationGUI confi = new ConfirmationGUI(plugin.getPlugin(), player,
+            ConfirmationGUI confi = new ConfirmationGUI(plugin, player,
                     lm.getRawString("Commands.Regenerate.confirmation").replace("%cost%", costString),
                     (p1) -> {
                         boolean flag = true;
@@ -83,7 +83,7 @@ public class Regenerate extends LandlordCommand {
                                             null, "REGENERATE", "REGENERATE");
                                     plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                 }
-                            }.runTask(plugin.getPlugin());
+                            }.runTask(plugin);
 
                             plugin.getRegenerationManager().regenerateChunk(finalLand.getALocation());
                             lm.sendMessage(player, lm.getString(player, "Commands.Regenerate.success")

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/borders/Borders.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/borders/Borders.java
@@ -36,7 +36,7 @@ public class Borders extends LandlordCommand implements Listener {
                 Sets.newHashSet(plugin.getConfig().getStringList("CommandSettings.Borders.aliases")));
         this.tasks = new HashMap<>();
 
-        this.plugin.getServer().getPluginManager().registerEvents(this, plugin.getPlugin());
+        this.plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }
 
     @Override

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/borders/BordersTask.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/borders/BordersTask.java
@@ -55,7 +55,7 @@ public class BordersTask extends BukkitRunnable {
     }
 
     public void start() {
-        runTaskTimer(plugin.getPlugin(), 0, refreshRate * 20L);
+        runTaskTimer(plugin, 0, refreshRate * 20L);
     }
 
 }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/guis/AManage.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/guis/AManage.java
@@ -43,18 +43,15 @@ public class AManage extends AbstractGUI {
     private final List<IOwnedLand> regions;
     private final ILangManager lm;
     private final ILandLord plugin;
-    private int flagPage = 0;
-
     private final Set<String> toggleMobs;
-
     private final IMaterialsManager mats;
-
     private final ManageMode manageMode;
     private final MultiMode multiMode;
     private final int radius;
+    private int flagPage = 0;
 
     AManage(ILandLord plugin, Player player, String header, List<IOwnedLand> land, ManageMode manageMode, MultiMode multiMode, int radius) {
-        super(plugin.getPlugin(), player, 45, header);
+        super(plugin, player, 45, header);
         this.plugin = plugin;
         this.regions = land;
         this.lm = plugin.getLangManager();
@@ -66,7 +63,7 @@ public class AManage extends AbstractGUI {
     }
 
     AManage(ILandLord plugin, Player player, MultiPagedGUI landGui, String header, List<IOwnedLand> land, ManageMode manageMode, MultiMode multiMode, int radius) {
-        super(plugin.getPlugin(), player, 54, header, landGui);
+        super(plugin, player, 54, header, landGui);
         this.plugin = plugin;
         this.regions = land;
         this.lm = plugin.getLangManager();
@@ -123,7 +120,7 @@ public class AManage extends AbstractGUI {
         for (ILLFlag flag : land.getFlags()) {
             String flagName = flag.getName();
             if (plugin.getConfig().getBoolean("Manage." + flagName + ".enable") &&
-                    player.hasPermission("landlord.player.manage." + flagName)) {
+                player.hasPermission("landlord.player.manage." + flagName)) {
                 flags.add(getIcons(flag));
             }
         }
@@ -202,7 +199,7 @@ public class AManage extends AbstractGUI {
                         for (IOwnedLand land : regions.subList(1, regions.size())) {
                             for (ILLFlag landFlag : land.getFlags()) {
                                 if (!flag.getName().equals(landFlag.getName())
-                                        || flag.getFriendStatus() == landFlag.getFriendStatus())
+                                    || flag.getFriendStatus() == landFlag.getFriendStatus())
                                     continue;
 
                                 landFlag.toggleFriends();
@@ -214,11 +211,11 @@ public class AManage extends AbstractGUI {
                                                 landFlag.getName(), !landFlag.getFriendStatus(), landFlag.getFriendStatus());
                                         plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                     }
-                                }.runTask(plugin.getPlugin());
+                                }.runTask(plugin);
                             }
                         }
                     }
-                }.runTaskAsynchronously(plugin.getPlugin());
+                }.runTaskAsynchronously(plugin);
             }
         });
         friend.setName(isFriend ? lm.getRawString("Commands.Manage.allow") : lm.getRawString("Commands.Manage.deny"));
@@ -235,7 +232,7 @@ public class AManage extends AbstractGUI {
                         for (IOwnedLand land : regions.subList(1, regions.size())) {
                             for (ILLFlag landFlag : land.getFlags()) {
                                 if (!flag.getName().equals(landFlag.getName())
-                                        || flag.getAllStatus() == landFlag.getAllStatus())
+                                    || flag.getAllStatus() == landFlag.getAllStatus())
                                     continue;
 
                                 landFlag.toggleAll();
@@ -247,11 +244,11 @@ public class AManage extends AbstractGUI {
                                                 landFlag.getName(), !landFlag.getFriendStatus(), landFlag.getFriendStatus());
                                         plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                     }
-                                }.runTask(plugin.getPlugin());
+                                }.runTask(plugin);
                             }
                         }
                     }
-                }.runTaskAsynchronously(plugin.getPlugin());
+                }.runTaskAsynchronously(plugin);
             }
         });
         all.setName(isAll ? lm.getRawString("Commands.Manage.allow") : lm.getRawString("Commands.Manage.deny"));
@@ -271,7 +268,7 @@ public class AManage extends AbstractGUI {
                 .getCommandString(Manage.class);
         // Set greet icon
         if (plugin.getConfig().getBoolean("Manage.setgreet.enable") &&
-                player.hasPermission("landlord.player.manage.setgreet")) {
+            player.hasPermission("landlord.player.manage.setgreet")) {
             String currentGreet = land.getGreetMessage();
             List<String> greetDesc = lm.getStringList("Commands.Manage.SetGreet.description");
 
@@ -301,12 +298,12 @@ public class AManage extends AbstractGUI {
 
         // set farewell icon
         if (plugin.getConfig().getBoolean("Manage.setfarewell.enable") &&
-                player.hasPermission("landlord.player.manage.setfarewell")) {
+            player.hasPermission("landlord.player.manage.setfarewell")) {
             List<String> farewellDesc = lm.getStringList("Commands.Manage.SetFarewell.description");
             String currentFarewell = land.getFarewellMessage();
 
             Icon icon = new Icon(new ItemStack(Material.valueOf(plugin.getConfig().getString("Manage.setfarewell" +
-                    ".item"))));
+                                                                                             ".item"))));
             icon.setName(lm.getRawString("Commands.Manage.SetFarewell.title"));
             icon.setLore(formatList(farewellDesc, "%var%", currentFarewell));
             icon.addClickAction(((p) -> {
@@ -332,15 +329,15 @@ public class AManage extends AbstractGUI {
 
         // set friends icon
         if (plugin.getConfig().getBoolean("Manage.friends.enable") &&
-                player.hasPermission("landlord.player.manage.friends")) {
+            player.hasPermission("landlord.player.manage.friends")) {
             Icon icon = new Icon(mats.getPlayerHead(player.getUniqueId()));
             icon.setName(lm.getRawString("Commands.Manage.ManageFriends.title"));
             icon.setLore(lm.getStringList("Commands.Manage.ManageFriends.description"));
 
             Set<UUID> friends = land.getFriends();
             boolean canSpread = plugin.getConfig().getBoolean("Manage.spread-friends.enable") &&
-                    player.hasPermission("landlord.player.manage.spreadfriends") && manageMode != ManageMode.ONE;
-            MultiPagedGUI friendsGui = new MultiPagedGUI(plugin.getPlugin(), player, (int) Math.ceil((double) friends.size() / 9.0),
+                                player.hasPermission("landlord.player.manage.spreadfriends") && manageMode != ManageMode.ONE;
+            MultiPagedGUI friendsGui = new MultiPagedGUI(plugin, player, (int) Math.ceil((double) friends.size() / 9.0),
                     lm.getRawString("Commands.Manage.ManageFriends.title"), new ArrayList<>(), this) {
                 @Override
                 protected void generateStaticIcons() {
@@ -374,10 +371,10 @@ public class AManage extends AbstractGUI {
                                                             "FRIENDS", oldfriends, region.getMembersString());
                                                     plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                                 }
-                                            }.runTask(plugin.getPlugin());
+                                            }.runTask(plugin);
                                         }
                                     }
-                                }.runTaskAsynchronously(plugin.getPlugin()));
+                                }.runTaskAsynchronously(plugin));
 
                         this.setIcon((int) Math.ceil((double) friends.size() / 9.0) + 1, spreadIcon);
                     }
@@ -394,15 +391,15 @@ public class AManage extends AbstractGUI {
                 friend.setName(name);
                 friend.setLore(formatFriendsSegment(id));
                 friend.addClickAction((player) -> {
-                    ConfirmationGUI confirmationGUI = new ConfirmationGUI(plugin.getPlugin(), this.player,
+                    ConfirmationGUI confirmationGUI = new ConfirmationGUI(plugin, this.player,
                             confititle,
                             (p) -> {
                                 friendsGui.removeIcon(friend);
 
                                 for (IOwnedLand region : regions) {
                                     plugin.getServer().dispatchCommand(player, PrincepsLib.getCommandManager()
-                                            .getCommand(Landlordbase.class).getCommandString(Unfriend.class)
-                                            .substring(1) + " " + name + " " + region.getName());
+                                                                                       .getCommand(Landlordbase.class).getCommandString(Unfriend.class)
+                                                                                       .substring(1) + " " + name + " " + region.getName());
                                 }
                                 player.closeInventory();
                                 friendsGui.display();
@@ -435,8 +432,8 @@ public class AManage extends AbstractGUI {
             // Config: Manage.commands.x
             // Language manager: Commands.Manage.x
             if (plugin.getConfig().getBoolean("Manage.commands." + key + ".enable") &&
-                    player.hasPermission("landlord.player.manage." + key) &&
-                    manageMode == ManageMode.ONE) {
+                player.hasPermission("landlord.player.manage." + key) &&
+                manageMode == ManageMode.ONE) {
                 List<String> descri = lm.getStringList("Commands.Manage." + key + ".description");
                 double cost = plugin.getConfig().getDouble("ResetCost");
                 String costString = (Options.isVaultEnabled() ? plugin.getVaultManager().format(cost) : "-1");
@@ -455,10 +452,10 @@ public class AManage extends AbstractGUI {
 
         // spawn management
         if (plugin.getConfig().getBoolean("Manage.mob-spawning.enable") &&
-                player.hasPermission("landlord.player.manage.mob-spawning")) {
+            player.hasPermission("landlord.player.manage.mob-spawning")) {
             String title = lm.getRawString("Commands.Manage.AllowMob-spawning.title");
             Icon icon = new Icon(new ItemStack(Material.valueOf(plugin.getConfig().getString("Manage.mob-spawning" +
-                    ".item"))));
+                                                                                             ".item"))));
             icon.setName(title);
             icon.setLore(lm.getStringList("Commands.Manage.AllowMob-spawning.description"));
 
@@ -466,11 +463,11 @@ public class AManage extends AbstractGUI {
                 List<Icon> icons = new ArrayList<>();
                 List<String> lore = lm.getStringList("Commands.Manage.AllowMob-spawning.toggleItem.description");
 
-                MultiPagedGUI gui = new MultiPagedGUI(plugin.getPlugin(), p, 5, title, icons, this) {
+                MultiPagedGUI gui = new MultiPagedGUI(plugin, p, 5, title, icons, this) {
                     @Override
                     protected void generateStaticIcons() {
                         if (plugin.getConfig().getBoolean("Manage.spread-mobs.enable") &&
-                                player.hasPermission("landlord.player.manage.spreadmobs") && manageMode != ManageMode.ONE) {
+                            player.hasPermission("landlord.player.manage.spreadmobs") && manageMode != ManageMode.ONE) {
                             String spreadTitle = lm.getRawString("Commands.Manage.AllowSpread-mobs.title");
                             Material material = Material.valueOf(plugin.getConfig().getString("Manage.spread-mobs" + ".item"));
                             Icon spreadIcon = new Icon(new ItemStack(material));
@@ -528,7 +525,7 @@ public class AManage extends AbstractGUI {
                                 setGlowing(mob.itemStack, !land.isMobDenied(m));
                                 gui.refresh();
                             }
-                        }.runTaskAsynchronously(plugin.getPlugin());
+                        }.runTaskAsynchronously(plugin);
                     });
                 }
 
@@ -539,7 +536,7 @@ public class AManage extends AbstractGUI {
         }
 
         if (plugin.getConfig().getBoolean("Manage.spread-flags.enable") &&
-                player.hasPermission("landlord.player.manage.spreadflags") && manageMode != ManageMode.ONE) {
+            player.hasPermission("landlord.player.manage.spreadflags") && manageMode != ManageMode.ONE) {
             String title = lm.getRawString("Commands.Manage.AllowSpread-flags.title");
             Material material = Material.valueOf(plugin.getConfig().getString("Manage.spread-flags" + ".item"));
             Icon icon = new Icon(new ItemStack(material));
@@ -566,7 +563,7 @@ public class AManage extends AbstractGUI {
                                                         landFlag.getName(), !landFlag.getFriendStatus(), landFlag.getFriendStatus());
                                                 plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                             }
-                                        }.runTask(plugin.getPlugin());
+                                        }.runTask(plugin);
                                     }
                                     if (defaultFlag.getAllStatus() != landFlag.getAllStatus()) {
                                         landFlag.toggleAll();
@@ -578,7 +575,7 @@ public class AManage extends AbstractGUI {
                                                         landFlag.getName(), !landFlag.getAllStatus(), landFlag.getAllStatus());
                                                 plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                             }
-                                        }.runTask(plugin.getPlugin());
+                                        }.runTask(plugin);
                                     }
                                 }
                             }
@@ -588,7 +585,7 @@ public class AManage extends AbstractGUI {
                                 region.setGreetMessage(land.getGreetMessage());
                             }
                         }
-                    }.runTaskAsynchronously(plugin.getPlugin()));
+                    }.runTaskAsynchronously(plugin));
 
             this.setIcon(position++, icon);
         }
@@ -648,4 +645,3 @@ public class AManage extends AbstractGUI {
     }
 
 }
-

--- a/LandLord-core/src/main/java/biz/princeps/landlord/guis/ClearGUI.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/guis/ClearGUI.java
@@ -26,7 +26,7 @@ public class ClearGUI extends AbstractGUI {
     private final IMultiTaskManager multiTaskManager;
 
     public ClearGUI(ILandLord plugin, Player player) {
-        super(plugin.getPlugin(), player, 9, plugin.getLangManager().getRawString("Commands.Clear.gui.title"));
+        super(plugin, player, 9, plugin.getLangManager().getRawString("Commands.Clear.gui.title"));
         this.plugin = plugin;
         this.lm = plugin.getLangManager();
         this.wg = plugin.getWGManager();
@@ -50,7 +50,7 @@ public class ClearGUI extends AbstractGUI {
                 i1.setName(lm.getRawString("Commands.Clear.gui.clearcurrentland.name"));
                 i1.setLore(Arrays.asList(lm.getRawString("Commands.Clear.gui.clearcurrentland.desc").split("\\|")));
                 i1.addClickAction((player1) -> {
-                    ConfirmationGUI confirm = new ConfirmationGUI(plugin.getPlugin(), player1,
+                    ConfirmationGUI confirm = new ConfirmationGUI(plugin, player1,
                             lm.getRawString("Commands.Clear.gui.clearcurrentland.confirm"),
                             (a) -> {
                                 clearLand(land);
@@ -71,7 +71,7 @@ public class ClearGUI extends AbstractGUI {
                 i2.setName(lm.getRawString("Commands.Clear.gui.clearplayer.name"));
                 i2.setLore(Arrays.asList(lm.getRawString("Commands.Clear.gui.clearplayer.desc").split("\\|")));
                 i2.addClickAction((player1) -> {
-                    ConfirmationGUI confirm = new ConfirmationGUI(plugin.getPlugin(), player1,
+                    ConfirmationGUI confirm = new ConfirmationGUI(plugin, player1,
                             lm.getRawString("Commands.Clear.gui.clearplayer.confirm"),
                             (a) -> {
                                 clearPlayer(land.getOwner());
@@ -93,7 +93,7 @@ public class ClearGUI extends AbstractGUI {
             i3.setName(lm.getRawString("Commands.Clear.gui.clearworld.name"));
             i3.setLore(Arrays.asList(lm.getRawString("Commands.Clear.gui.clearworld.desc").split("\\|")));
             i3.addClickAction((player1) -> {
-                ConfirmationGUI confirm = new ConfirmationGUI(plugin.getPlugin(), player1,
+                ConfirmationGUI confirm = new ConfirmationGUI(plugin, player1,
                         lm.getRawString("Commands.Clear.gui.clearworld.confirm").replace("%world%",
                                 player.getWorld().getName()),
                         (a) -> {

--- a/LandLord-core/src/main/java/biz/princeps/landlord/guis/ShopGUI.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/guis/ShopGUI.java
@@ -33,7 +33,7 @@ public class ShopGUI extends AbstractGUI {
     private double cost = 0;
 
     public ShopGUI(ILandLord plugin, Player player, String title) {
-        super(plugin.getPlugin(), player, 54, title);
+        super(plugin, player, 54, title);
         this.plugin = plugin;
         this.costManager = new ClaimsCostManager(plugin);
         this.mats = plugin.getMaterialsManager();

--- a/LandLord-core/src/main/java/biz/princeps/landlord/integrations/LLLuckPerms.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/integrations/LLLuckPerms.java
@@ -12,8 +12,8 @@ import org.bukkit.plugin.RegisteredServiceProvider;
 
 public class LLLuckPerms {
 
-    private LuckPerms api;
     private final ILandLord plugin;
+    private LuckPerms api;
 
     public LLLuckPerms(ILandLord plugin) {
         this.plugin = plugin;
@@ -55,4 +55,3 @@ public class LLLuckPerms {
         }
     }
 }
-

--- a/LandLord-core/src/main/java/biz/princeps/landlord/integrations/Towny.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/integrations/Towny.java
@@ -26,7 +26,7 @@ public class Towny extends BasicListener {
     public void onLLClaim(LandPreClaimEvent e) {
         Chunk chunk = e.getChunk();
         if (towny.isTownyWorld(e.getChunk().getWorld()) &&
-                !towny.isWilderness(new Location(chunk.getWorld(), (chunk.getX() << 4) + 2, 2, (chunk.getZ() << 4) + 2))) {
+            !towny.isWilderness(new Location(chunk.getWorld(), (chunk.getX() << 4) + 2, 2, (chunk.getZ() << 4) + 2))) {
             plugin.getLangManager().sendMessage(e.getPlayer(), "Integrations.Towny.TownyPresent");
             e.setCancelled(true);
         }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/listener/BasicListener.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/listener/BasicListener.java
@@ -16,7 +16,7 @@ public abstract class BasicListener implements Listener {
 
     public BasicListener(ILandLord plugin) {
         this.plugin = plugin;
-        plugin.getServer().getPluginManager().registerEvents(this, plugin.getPlugin());
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }
 
 }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/listener/MapListener.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/listener/MapListener.java
@@ -51,8 +51,7 @@ public class MapListener extends BasicListener {
             public void run() {
                 plugin.getMapManager().updateAll();
             }
-        }.runTaskLater(plugin.getPlugin(), 15L);
+        }.runTaskLater(plugin, 15L);
     }
 
 }
-

--- a/LandLord-core/src/main/java/biz/princeps/landlord/manager/DelimitationManager.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/manager/DelimitationManager.java
@@ -98,8 +98,8 @@ public class DelimitationManager implements IDelimitationManager {
                     Block b = chunk.getBlock(x, highestY, z);
 
                     while (b.getType() != Material.AIR &&
-                            b.getType() != plugin.getMaterialsManager().getGrass() &&
-                            b.getType() != plugin.getMaterialsManager().getLongGrass()) {
+                           b.getType() != plugin.getMaterialsManager().getGrass() &&
+                           b.getType() != plugin.getMaterialsManager().getLongGrass()) {
                         b = chunk.getBlock(x, ++highestY, z);
                     }
 
@@ -126,9 +126,9 @@ public class DelimitationManager implements IDelimitationManager {
         @Override
         public String toString() {
             return "BlockVector{" +
-                    "x=" + x +
-                    ", z=" + z +
-                    '}';
+                   "x=" + x +
+                   ", z=" + z +
+                   '}';
         }
 
         @Override

--- a/LandLord-core/src/main/java/biz/princeps/landlord/manager/LPlayerManager.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/manager/LPlayerManager.java
@@ -36,9 +36,9 @@ public class LPlayerManager implements IPlayerManager {
         this.plugin = plugin;
 
         if (plugin.getConfig().getString("DatabaseType").equalsIgnoreCase("MySQL")) {
-            this.stor = new SQLStorage(plugin.getPlugin());
+            this.stor = new SQLStorage(plugin);
         } else {
-            this.stor = new FlatFileStorage(plugin.getPlugin());
+            this.stor = new FlatFileStorage(plugin);
             ((FlatFileStorage) this.stor).init();
         }
     }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/manager/LangManager.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/manager/LangManager.java
@@ -27,29 +27,29 @@ public class LangManager implements ILangManager {
 
     private final ILandLord plugin;
     private final String filename;
-    private FileConfiguration msg;
     private final boolean parsePlaceholders;
+    private FileConfiguration msg;
 
     public LangManager(ILandLord plugin, String lang) {
         this.plugin = plugin;
         filename = "messages/" + lang + ".yml";
         reload();
-        new ConfigUtil(plugin).handleConfigUpdate(plugin.getPlugin().getDataFolder() + "/" + filename, "/" + filename);
+        new ConfigUtil(plugin).handleConfigUpdate(plugin.getDataFolder() + "/" + filename, "/" + filename);
         reload();
         parsePlaceholders = plugin.getServer().getPluginManager().isPluginEnabled("PlaceholderAPI");
     }
 
     @Override
     public void reload() {
-        File f = new File(plugin.getPlugin().getDataFolder(), filename);
+        File f = new File(plugin.getDataFolder(), filename);
         this.msg = new YamlConfiguration();
         try {
-            File folder = new File(plugin.getPlugin().getDataFolder(), "messages");
+            File folder = new File(plugin.getDataFolder(), "messages");
             if (!folder.exists())
                 folder.mkdir();
 
             if (!f.exists())
-                plugin.getPlugin().saveResource(filename, false);
+                plugin.saveResource(filename, false);
 
             this.msg.load(f);
         } catch (IOException | InvalidConfigurationException e) {

--- a/LandLord-core/src/main/java/biz/princeps/landlord/manager/cost/ACostManager.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/manager/cost/ACostManager.java
@@ -24,21 +24,21 @@ public abstract class ACostManager implements ICostManager {
         switch (func.toLowerCase()) {
             default:
                 plugin.getLogger().warning("Illegal function [" + func + "] detected! The plugin will default to " +
-                        "linear");
+                                           "linear");
             case "linear":
-                this.strategy = new LinearStrategy(plugin.getPlugin(), namespace, free);
+                this.strategy = new LinearStrategy(plugin, namespace, free);
                 break;
             case "exponential":
-                this.strategy = new ExponentialStrategy(plugin.getPlugin(), namespace, free);
+                this.strategy = new ExponentialStrategy(plugin, namespace, free);
                 break;
             case "limited":
-                this.strategy = new LimitedStrategy(plugin.getPlugin(), namespace, free);
+                this.strategy = new LimitedStrategy(plugin, namespace, free);
                 break;
             case "logarithmic":
-                this.strategy = new LogarithmicStrategy(plugin.getPlugin(), namespace, free);
+                this.strategy = new LogarithmicStrategy(plugin, namespace, free);
                 break;
             case "sinus":
-                this.strategy = new SinusStrategy(plugin.getPlugin(), namespace, free);
+                this.strategy = new SinusStrategy(plugin, namespace, free);
                 break;
         }
     }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/manager/cost/ExponentialStrategy.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/manager/cost/ExponentialStrategy.java
@@ -1,15 +1,15 @@
 package biz.princeps.landlord.manager.cost;
 
 import biz.princeps.landlord.api.ICostStrategy;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 
 public class ExponentialStrategy implements ICostStrategy {
 
-    private final JavaPlugin plugin;
+    private final Plugin plugin;
     private final int free;
     private final String namespace;
 
-    public ExponentialStrategy(JavaPlugin plugin, String namespace, int free) {
+    public ExponentialStrategy(Plugin plugin, String namespace, int free) {
         this.plugin = plugin;
         this.free = free;
         this.namespace = namespace;

--- a/LandLord-core/src/main/java/biz/princeps/landlord/manager/cost/LimitedStrategy.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/manager/cost/LimitedStrategy.java
@@ -1,15 +1,15 @@
 package biz.princeps.landlord.manager.cost;
 
 import biz.princeps.landlord.api.ICostStrategy;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 
 public class LimitedStrategy implements ICostStrategy {
 
-    private final JavaPlugin plugin;
+    private final Plugin plugin;
     private final int free;
     private final String namespace;
 
-    public LimitedStrategy(JavaPlugin plugin, String namespace, int free) {
+    public LimitedStrategy(Plugin plugin, String namespace, int free) {
         this.plugin = plugin;
         this.free = free;
         this.namespace = namespace;

--- a/LandLord-core/src/main/java/biz/princeps/landlord/manager/cost/LinearStrategy.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/manager/cost/LinearStrategy.java
@@ -1,15 +1,15 @@
 package biz.princeps.landlord.manager.cost;
 
 import biz.princeps.landlord.api.ICostStrategy;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 
 public class LinearStrategy implements ICostStrategy {
 
-    private final JavaPlugin plugin;
+    private final Plugin plugin;
     private final int free;
     private final String namespace;
 
-    public LinearStrategy(JavaPlugin plugin, String namespace, int free) {
+    public LinearStrategy(Plugin plugin, String namespace, int free) {
         this.plugin = plugin;
         this.free = free;
         this.namespace = namespace;

--- a/LandLord-core/src/main/java/biz/princeps/landlord/manager/cost/LogarithmicStrategy.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/manager/cost/LogarithmicStrategy.java
@@ -1,15 +1,15 @@
 package biz.princeps.landlord.manager.cost;
 
 import biz.princeps.landlord.api.ICostStrategy;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 
 public class LogarithmicStrategy implements ICostStrategy {
 
-    private final JavaPlugin plugin;
+    private final Plugin plugin;
     private final int free;
     private final String namespace;
 
-    public LogarithmicStrategy(JavaPlugin plugin, String namespace, int free) {
+    public LogarithmicStrategy(Plugin plugin, String namespace, int free) {
         this.plugin = plugin;
         this.free = free;
         this.namespace = namespace;

--- a/LandLord-core/src/main/java/biz/princeps/landlord/manager/cost/SinusStrategy.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/manager/cost/SinusStrategy.java
@@ -1,15 +1,15 @@
 package biz.princeps.landlord.manager.cost;
 
 import biz.princeps.landlord.api.ICostStrategy;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 
 public class SinusStrategy implements ICostStrategy {
 
-    private final JavaPlugin plugin;
+    private final Plugin plugin;
     private final int free;
     private final String namespace;
 
-    public SinusStrategy(JavaPlugin plugin, String namespace, int free) {
+    public SinusStrategy(Plugin plugin, String namespace, int free) {
         this.plugin = plugin;
         this.free = free;
         this.namespace = namespace;

--- a/LandLord-core/src/main/java/biz/princeps/landlord/manager/map/LandMap.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/manager/map/LandMap.java
@@ -161,7 +161,7 @@ public class LandMap {
     private SimpleScoreboard displayMap(Player p) {
         scoreboard = new SimpleScoreboard(plugin, header, p);
 
-        scoreboard.scheduleUpdate(plugin.getPlugin(), new Runnable() {
+        scoreboard.scheduleUpdate(plugin, new Runnable() {
             List<String> prev;
 
             @Override

--- a/LandLord-core/src/main/java/biz/princeps/landlord/multi/MultiClearInactiveTask.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/multi/MultiClearInactiveTask.java
@@ -57,7 +57,7 @@ public class MultiClearInactiveTask extends AMultiTask<OfflinePlayer> {
             public void run() {
                 plugin.getMapManager().updateAll();
             }
-        }.runTask(plugin.getPlugin());
+        }.runTask(plugin);
     }
 
 }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/multi/MultiClearTask.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/multi/MultiClearTask.java
@@ -99,7 +99,7 @@ public class MultiClearTask extends AMultiTask<IOwnedLand> {
             public void run() {
                 plugin.getMapManager().updateAll();
             }
-        }.runTask(plugin.getPlugin());
+        }.runTask(plugin);
     }
 
 }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/multi/MultiTaskManager.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/multi/MultiTaskManager.java
@@ -29,7 +29,7 @@ public class MultiTaskManager implements IMultiTaskManager {
                 // 10 operations max per tick seems adequate for the majority of cases.
                 processQueue(10);
             }
-        }.runTaskTimer(plugin.getPlugin(), 0L, 1L);
+        }.runTaskTimer(plugin, 0L, 1L);
     }
 
     @Override
@@ -63,7 +63,7 @@ public class MultiTaskManager implements IMultiTaskManager {
                 public void run() {
                     enqueueTask(multiTask);
                 }
-            }.runTask(plugin.getPlugin());
+            }.runTask(plugin);
         }
     }
 

--- a/LandLord-core/src/main/java/biz/princeps/landlord/multi/MultiUnclaimTask.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/multi/MultiUnclaimTask.java
@@ -115,7 +115,7 @@ public class MultiUnclaimTask extends AMultiTask<IOwnedLand> {
             public void run() {
                 plugin.getMapManager().updateAll();
             }
-        }.runTask(plugin.getPlugin());
+        }.runTask(plugin);
     }
 
 }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/persistent/FlatFileStorage.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/persistent/FlatFileStorage.java
@@ -8,7 +8,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.io.File;
@@ -18,12 +18,12 @@ import java.util.function.Consumer;
 
 public class FlatFileStorage implements IStorage {
 
-    private final JavaPlugin plugin;
+    private final Plugin plugin;
 
     private File customConfigFile;
     private FileConfiguration customConfig;
 
-    public FlatFileStorage(JavaPlugin plugin) {
+    public FlatFileStorage(Plugin plugin) {
         this.plugin = plugin;
     }
 

--- a/LandLord-core/src/main/java/biz/princeps/landlord/persistent/LPlayer.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/persistent/LPlayer.java
@@ -74,11 +74,11 @@ public class LPlayer implements IPlayer {
     @Override
     public String toString() {
         return "LPlayer{" +
-                "uuid=" + uuid +
-                ", name='" + name + '\'' +
-                ", claims=" + claims +
-                ", home=" + home +
-                ", lastseen='" + getLastSeen() + '\'' +
-                '}';
+               "uuid=" + uuid +
+               ", name='" + name + '\'' +
+               ", claims=" + claims +
+               ", home=" + home +
+               ", lastseen='" + getLastSeen() + '\'' +
+               '}';
     }
 }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/persistent/SQLStorage.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/persistent/SQLStorage.java
@@ -5,7 +5,7 @@ import biz.princeps.landlord.api.IStorage;
 import biz.princeps.lib.storage.Datastorage;
 import biz.princeps.lib.util.SpigotUtil;
 import biz.princeps.lib.util.TimeUtil;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.sql.ResultSet;
@@ -17,7 +17,7 @@ public class SQLStorage extends Datastorage implements IStorage {
 
     private static final int CURRENT_VERSION = 4;
 
-    public SQLStorage(JavaPlugin plugin) {
+    public SQLStorage(Plugin plugin) {
         super(plugin,
                 plugin.getConfig().getString("MySQL.Hostname"),
                 plugin.getConfig().getString("MySQL.Port"),
@@ -121,9 +121,9 @@ public class SQLStorage extends Datastorage implements IStorage {
     @Override
     public void savePlayer(IPlayer lp, boolean async) {
         Runnable r = () -> execute("REPLACE INTO ll_players (uuid, name, claims, home, lastseen) VALUES ('" + lp.getUuid() + "', '" +
-                lp.getName() + "', " + lp.getClaims() + ", '" +
-                SpigotUtil.exactlocationToString(lp.getHome()) + "', '" +
-                TimeUtil.timeToString(lp.getLastSeen()) + "')");
+                                   lp.getName() + "', " + lp.getClaims() + ", '" +
+                                   SpigotUtil.exactlocationToString(lp.getHome()) + "', '" +
+                                   TimeUtil.timeToString(lp.getLastSeen()) + "')");
         if (async) {
             new BukkitRunnable() {
                 @Override

--- a/LandLord-core/src/main/java/biz/princeps/landlord/placeholderapi/LLExpansion.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/placeholderapi/LLExpansion.java
@@ -41,12 +41,12 @@ public class LLExpansion extends PlaceholderExpansion {
 
     @Override
     public String getAuthor() {
-        return String.valueOf(plugin.getPlugin().getDescription().getAuthors());
+        return String.valueOf(plugin.getDescription().getAuthors());
     }
 
     @Override
     public String getVersion() {
-        return plugin.getPlugin().getDescription().getVersion();
+        return plugin.getDescription().getVersion();
     }
 
     @Override
@@ -85,7 +85,7 @@ public class LLExpansion extends PlaceholderExpansion {
                 IPlayer iPlayer = plugin.getPlayerManager().get(player.getUniqueId());
                 if (iPlayer == null) {
                     plugin.getLogger().warning("A placeholder is trying to load %landlord_claims% before async loading of the " +
-                            "player has finished! Use FinishedLoadingPlayerEvent!");
+                                               "player has finished! Use FinishedLoadingPlayerEvent!");
                     return "NaN";
                 }
                 return String.valueOf(iPlayer.getClaims());
@@ -95,7 +95,7 @@ public class LLExpansion extends PlaceholderExpansion {
                 IPlayer iPlayer2 = plugin.getPlayerManager().get(player.getUniqueId());
                 if (iPlayer2 == null) {
                     plugin.getLogger().warning("A placeholder is trying to load %landlord_remainingClaims% before async loading of the " +
-                            "player has finished! Use FinishedLoadingPlayerEvent!");
+                                               "player has finished! Use FinishedLoadingPlayerEvent!");
                     return "NaN";
                 }
                 return String.valueOf(iPlayer2.getClaims() - wg.getRegionCount(player.getUniqueId()));

--- a/LandLord-core/src/main/java/biz/princeps/landlord/placeholderapi/LLFeatherBoard.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/placeholderapi/LLFeatherBoard.java
@@ -17,13 +17,13 @@ public class LLFeatherBoard {
     private void registerPlaceholders(ILandLord plugin) {
         plugin.getLogger().warning("Featherboard Placeholders do not work. Please tell Maxim from Featherboard to take a look at the MVdWPlaceholderAPI repo.");
         /*
-        PlaceholderAPI.registerPlaceholder(plugin.getPlugin(), "ownedlands",
+        PlaceholderAPI.registerPlaceholder(plugin, "ownedlands",
                 e -> {
                     int landcount = wg.getRegionCount(e.getPlayer().getUniqueId());
                     return String.valueOf(landcount);
                 }
         );
-        PlaceholderAPI.registerPlaceholder(plugin.getPlugin(), "claims",
+        PlaceholderAPI.registerPlaceholder(plugin, "claims",
                 e -> {
                     IPlayer player1 = plugin.getPlayerManager().get(e.getPlayer().getUniqueId());
                     if (player1 == null) {
@@ -34,7 +34,7 @@ public class LLFeatherBoard {
                     return String.valueOf(player1.getClaims());
                 }
         );
-        PlaceholderAPI.registerPlaceholder(plugin.getPlugin(), "currentLandOwner",
+        PlaceholderAPI.registerPlaceholder(plugin, "currentLandOwner",
                 e -> {
                     IOwnedLand region = wg.getRegion(e.getPlayer().getLocation());
                     if (region != null) {
@@ -43,13 +43,13 @@ public class LLFeatherBoard {
                     return "";
                 }
         );
-        PlaceholderAPI.registerPlaceholder(plugin.getPlugin(), "currentLandName",
+        PlaceholderAPI.registerPlaceholder(plugin, "currentLandName",
                 e -> wg.getLandName(e.getPlayer().getLocation().getChunk())
         );
-        PlaceholderAPI.registerPlaceholder(plugin.getPlugin(), "nextLandPrice",
+        PlaceholderAPI.registerPlaceholder(plugin, "nextLandPrice",
                 e -> String.valueOf(plugin.getCostManager().calculateCost(e.getPlayer().getUniqueId()))
         );
-        PlaceholderAPI.registerPlaceholder(plugin.getPlugin(), "currentLandRefund",
+        PlaceholderAPI.registerPlaceholder(plugin, "currentLandRefund",
                 e -> {
                     int regionCount = wg.getRegionCount(e.getPlayer().getUniqueId());
                     return String.valueOf(plugin.getCostManager().calculateCost(regionCount - 1) *

--- a/LandLord-core/src/main/java/biz/princeps/landlord/util/ConfigUtil.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/util/ConfigUtil.java
@@ -50,8 +50,8 @@ public class ConfigUtil {
             reader = new BufferedReader(new InputStreamReader(resourceAsStream));
         else {
             plugin.getLogger().warning("You are using an unknown translation.\n" +
-                    "Please be aware, that LandLord will not add any new strings to your translation.\n" +
-                    "If you would like to see your translation inside the plugin, please contact the author!");
+                                       "Please be aware, that LandLord will not add any new strings to your translation.\n" +
+                                       "If you would like to see your translation inside the plugin, please contact the author!");
             return;
         }
         reader.lines().forEach(s -> {

--- a/LandLord-core/src/main/java/biz/princeps/landlord/util/JavaUtils.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/util/JavaUtils.java
@@ -13,6 +13,8 @@ import java.util.regex.Pattern;
 
 public class JavaUtils {
 
+    public static final BlockFace[] BLOCK_FACES = new BlockFace[]{BlockFace.SOUTH, BlockFace.WEST, BlockFace.NORTH, BlockFace.EAST};
+
     public static double round(double value, int places) {
         if (places < 0) throw new IllegalArgumentException();
 
@@ -49,8 +51,6 @@ public class JavaUtils {
         }
         return false;
     }
-
-    public static final BlockFace[] BLOCK_FACES = new BlockFace[]{BlockFace.SOUTH, BlockFace.WEST, BlockFace.NORTH, BlockFace.EAST};
 
     /**
      * Original link : https://github.com/bergerhealer/BKCommonLib/blob/master/src/main/java/com/bergerkiller/bukkit/common/utils/FaceUtil.java

--- a/LandLord-core/src/main/java/biz/princeps/landlord/util/SimpleScoreboard.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/util/SimpleScoreboard.java
@@ -3,7 +3,7 @@ package biz.princeps.landlord.util;
 import biz.princeps.landlord.api.ILandLord;
 import com.google.common.base.Preconditions;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.scoreboard.Objective;
@@ -16,11 +16,10 @@ import java.util.Objects;
 public class SimpleScoreboard {
 
     private final ILandLord plugin;
-    private Scoreboard scoreboard;
-
     private final String title;
     private final List<String> scores;
     private final Player player;
+    private Scoreboard scoreboard;
     private BukkitRunnable runnable;
 
     /**
@@ -116,7 +115,7 @@ public class SimpleScoreboard {
      * @param delay  ~ delay
      * @param timer  the repeating time
      */
-    public void scheduleUpdate(JavaPlugin plugin, Runnable run, long delay, long timer) {
+    public void scheduleUpdate(Plugin plugin, Runnable run, long delay, long timer) {
         this.runnable = new BukkitRunnable() {
             @Override
             public void run() {

--- a/LandLord-core/src/main/java/biz/princeps/landlord/util/Skulls.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/util/Skulls.java
@@ -42,30 +42,6 @@ public enum Skulls {
         this.texture = texture;
     }
 
-    public ItemStack getSkull(ILandLord plugin) {
-        UUID uuid = UUID.randomUUID();
-        ItemStack head = plugin.getMaterialsManager().getPlayerHead(uuid);
-        if (texture.isEmpty())
-            return head;
-
-        SkullMeta headMeta = (SkullMeta) head.getItemMeta();
-        GameProfile profile = new GameProfile(uuid, null);
-
-        profile.getProperties().put("textures", new Property("textures", texture));
-
-        try {
-            Field profileField = headMeta.getClass().getDeclaredField("profile");
-            profileField.setAccessible(true);
-            profileField.set(headMeta, profile);
-
-        } catch (IllegalArgumentException | NoSuchFieldException | SecurityException | IllegalAccessException error) {
-            error.printStackTrace();
-        }
-        head.setItemMeta(headMeta);
-        return head;
-    }
-
-
     public static List<Skulls> numToSkull(int num) {
         List<Skulls> list = new ArrayList<>();
         String numstring = String.valueOf(num);
@@ -109,11 +85,33 @@ public enum Skulls {
         return list;
     }
 
+    public ItemStack getSkull(ILandLord plugin) {
+        UUID uuid = UUID.randomUUID();
+        ItemStack head = plugin.getMaterialsManager().getPlayerHead(uuid);
+        if (texture.isEmpty())
+            return head;
+
+        SkullMeta headMeta = (SkullMeta) head.getItemMeta();
+        GameProfile profile = new GameProfile(uuid, null);
+
+        profile.getProperties().put("textures", new Property("textures", texture));
+
+        try {
+            Field profileField = headMeta.getClass().getDeclaredField("profile");
+            profileField.setAccessible(true);
+            profileField.set(headMeta, profile);
+
+        } catch (IllegalArgumentException | NoSuchFieldException | SecurityException | IllegalAccessException error) {
+            error.printStackTrace();
+        }
+        head.setItemMeta(headMeta);
+        return head;
+    }
 
     @Override
     public String toString() {
         return "Skulls{" +
-                this.name() +
-                '}';
+               this.name() +
+               '}';
     }
 }

--- a/LandLord-core/src/main/java/biz/princeps/lib/ConfigUpdater.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/ConfigUpdater.java
@@ -21,7 +21,7 @@ public class ConfigUpdater {
      * The destination file is supposed to receive all entries, that are in source but not in dest.
      *
      * @param source the *.yml path
-     * @param dest the destination file
+     * @param dest   the destination file
      */
     public static void updateConfig(String source, File dest) {
         File sourceFile = null;

--- a/LandLord-core/src/main/java/biz/princeps/lib/PrincepsLib.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/PrincepsLib.java
@@ -27,11 +27,6 @@ public class PrincepsLib extends JavaPlugin implements Listener {
     private static Stuff STUFF_MANAGER;
     private static TranslateableStrings TRANSLATEABLE_STRINGS;
 
-    @Override
-    public void onEnable() {
-        setPluginInstance(this);
-    }
-
     /**
      * @return your own plugin instance, which you set before
      */
@@ -114,6 +109,11 @@ public class PrincepsLib extends JavaPlugin implements Listener {
 
     public static TranslateableStrings getTranslateableStrings() {
         return TRANSLATEABLE_STRINGS;
+    }
+
+    @Override
+    public void onEnable() {
+        setPluginInstance(this);
     }
 
 }

--- a/LandLord-core/src/main/java/biz/princeps/lib/chat/ConfirmationDialog.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/chat/ConfirmationDialog.java
@@ -65,11 +65,23 @@ public class ConfirmationDialog {
 
     static class DialogHandler implements Listener {
 
+        private static final Map<UUID, ConfirmationDialog> openDialogs = new HashMap<>();
+
         private DialogHandler() {
             PrincepsLib.getPluginInstance().getServer().getPluginManager().registerEvents(this, PrincepsLib.getPluginInstance());
         }
 
-        private static final Map<UUID, ConfirmationDialog> openDialogs = new HashMap<>();
+        public synchronized static void addPlayer(UUID uniqueId, ConfirmationDialog confirmationDialog) {
+            openDialogs.put(uniqueId, confirmationDialog);
+        }
+
+        public synchronized static void removePlayer(UUID uniqueId) {
+            openDialogs.remove(uniqueId);
+        }
+
+        public synchronized static boolean contains(UUID uuid) {
+            return openDialogs.containsKey(uuid);
+        }
 
         @EventHandler
         public void onCommand(PlayerCommandPreprocessEvent event) {
@@ -85,18 +97,6 @@ public class ConfirmationDialog {
 
         public synchronized ConfirmationDialog get(UUID id) {
             return openDialogs.get(id);
-        }
-
-        public synchronized static void addPlayer(UUID uniqueId, ConfirmationDialog confirmationDialog) {
-            openDialogs.put(uniqueId, confirmationDialog);
-        }
-
-        public synchronized static void removePlayer(UUID uniqueId) {
-            openDialogs.remove(uniqueId);
-        }
-
-        public synchronized static boolean contains(UUID uuid) {
-            return openDialogs.containsKey(uuid);
         }
     }
 }

--- a/LandLord-core/src/main/java/biz/princeps/lib/chat/MultiPagedMessage.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/chat/MultiPagedMessage.java
@@ -16,13 +16,11 @@ import java.util.List;
 public class MultiPagedMessage {
 
     private final String command;
-
-    private String header;
     private final int perSite;
     private final List<String> elements;
     private final String previous;
     private final String next;
-
+    private String header;
     private int pointer;
 
     /**

--- a/LandLord-core/src/main/java/biz/princeps/lib/command/CommandManager.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/command/CommandManager.java
@@ -23,10 +23,10 @@ public class CommandManager {
 
     // A set of all registered commands. Might need it later
     private final Set<MainCommand> commandSet;
-    // The internal command map of bukkit
-    private CommandMap cmdMap;
     // Instance of the javaplugin, which is using PrincepsLib
     private final JavaPlugin plugin;
+    // The internal command map of bukkit
+    private CommandMap cmdMap;
 
     /**
      * Creates a new CommandManager and tries to initialize the commandMap from Bukkit

--- a/LandLord-core/src/main/java/biz/princeps/lib/command/SubCommand.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/command/SubCommand.java
@@ -34,11 +34,11 @@ public abstract class SubCommand implements Command {
     @Override
     public String toString() {
         return "SubCommand{" +
-                "permissions=" + permissions +
-                ", name='" + name + '\'' +
-                ", usage='" + usage + '\'' +
-                ", aliases=" + aliases +
-                '}';
+               "permissions=" + permissions +
+               ", name='" + name + '\'' +
+               ", usage='" + usage + '\'' +
+               ", aliases=" + aliases +
+               '}';
     }
 
     /**

--- a/LandLord-core/src/main/java/biz/princeps/lib/crossversion/CrossVersion.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/crossversion/CrossVersion.java
@@ -14,6 +14,10 @@ public class CrossVersion {
         this.item = new Item();
     }
 
+    public static String getVersion() {
+        return Bukkit.getServer().getClass().getPackage().getName().replace(".", ",").split(",")[3];
+    }
+
     public ItemStack addNBTTag(ItemStack stack, String key, Object value) {
         return item.addNBTTag(stack, key, value);
     }
@@ -24,10 +28,6 @@ public class CrossVersion {
 
     public boolean hasNBTTag(ItemStack stack, String customItem) {
         return item.hasNBTTag(stack, customItem);
-    }
-
-    public static String getVersion() {
-        return Bukkit.getServer().getClass().getPackage().getName().replace(".", ",").split(",")[3];
     }
 
 }

--- a/LandLord-core/src/main/java/biz/princeps/lib/gui/ConfirmationGUI.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/gui/ConfirmationGUI.java
@@ -8,7 +8,7 @@ import biz.princeps.lib.gui.simple.Icon;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 
 /**
  * Created by spatium on 21.07.17.
@@ -20,7 +20,7 @@ public class ConfirmationGUI extends AbstractGUI {
     private String confirm = PrincepsLib.getTranslateableStrings().get("Confirmation.accept");
     private String decline = PrincepsLib.getTranslateableStrings().get("Confirmation.decline");
 
-    public ConfirmationGUI(JavaPlugin plugin, Player player, String msg, Action onAccept, Action onDecline, AbstractGUI mainMenu) {
+    public ConfirmationGUI(Plugin plugin, Player player, String msg, Action onAccept, Action onDecline, AbstractGUI mainMenu) {
         super(plugin, player, 9, msg, mainMenu);
         this.onAccept = onAccept;
         this.onDecline = onDecline;

--- a/LandLord-core/src/main/java/biz/princeps/lib/gui/MultiPagedGUI.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/gui/MultiPagedGUI.java
@@ -6,7 +6,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +31,7 @@ public class MultiPagedGUI extends AbstractGUI {
      * @param icons       a list of icons which should be displayed on more pages
      * @param main        the superior main menu
      */
-    public MultiPagedGUI(JavaPlugin plugin, Player player, int rowsPerSite, String title, List<Icon> icons, AbstractGUI main) {
+    public MultiPagedGUI(Plugin plugin, Player player, int rowsPerSite, String title, List<Icon> icons, AbstractGUI main) {
         super(plugin, player, rowsPerSite * 9 + 9, title, main);
         this.icons = icons;
         this.rowsPerSite = rowsPerSite;
@@ -46,7 +46,7 @@ public class MultiPagedGUI extends AbstractGUI {
      * @param rowsPerSite a value between 0 and 5
      * @param title       the name of the menu - ChatColor allowed!
      */
-    public MultiPagedGUI(JavaPlugin plugin, Player player, int rowsPerSite, String title) {
+    public MultiPagedGUI(Plugin plugin, Player player, int rowsPerSite, String title) {
         this(plugin, player, rowsPerSite, title, new ArrayList<>(), null);
     }
 

--- a/LandLord-core/src/main/java/biz/princeps/lib/gui/simple/AbstractGUI.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/gui/simple/AbstractGUI.java
@@ -10,7 +10,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.HashMap;
@@ -27,15 +27,14 @@ public abstract class AbstractGUI implements InventoryHolder {
         new InventoryClickListener();
     }
 
-    private final JavaPlugin plugin;
+    private final Plugin plugin;
     private final Map<Integer, Icon> icons;
-    private int size;
     protected String title, rawTitle;
     protected AbstractGUI mainMenu;
     protected boolean generateAsync;
-
     protected Player player;
     protected Inventory inventory;
+    private int size;
 
     /**
      * Creates a new main menu
@@ -45,7 +44,7 @@ public abstract class AbstractGUI implements InventoryHolder {
      * @param size   the size of the inventory. must be a multiple of 9 (starting at 0)
      * @param title  the name of the menu - ChatColor allowed!
      */
-    public AbstractGUI(JavaPlugin plugin, Player player, int size, String title) {
+    public AbstractGUI(Plugin plugin, Player player, int size, String title) {
         this(plugin, player, size, title, null);
     }
 
@@ -58,7 +57,7 @@ public abstract class AbstractGUI implements InventoryHolder {
      * @param title    the name of the menu - ChatColor allowed!
      * @param mainMenu The superior menu
      */
-    public AbstractGUI(JavaPlugin plugin, Player player, int size, String title, AbstractGUI mainMenu) {
+    public AbstractGUI(Plugin plugin, Player player, int size, String title, AbstractGUI mainMenu) {
         this.plugin = plugin;
         this.player = player;
         this.icons = new HashMap<>();
@@ -113,14 +112,6 @@ public abstract class AbstractGUI implements InventoryHolder {
         return title;
     }
 
-    public String getRawTitle() {
-        return rawTitle;
-    }
-
-    public int getSize() {
-        return size;
-    }
-
     /**
      * Sets the title of the GUI
      * It is not possible to update the title once the gui is created!
@@ -129,6 +120,14 @@ public abstract class AbstractGUI implements InventoryHolder {
      */
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    public String getRawTitle() {
+        return rawTitle;
+    }
+
+    public int getSize() {
+        return size;
     }
 
     public void setSize(int size) {
@@ -214,9 +213,9 @@ public abstract class AbstractGUI implements InventoryHolder {
     @Override
     public String toString() {
         return "AbstractGUI{" +
-                "size=" + size +
-                ", title='" + title + '\'' +
-                '}';
+               "size=" + size +
+               ", title='" + title + '\'' +
+               '}';
     }
 
     static class InventoryClickListener implements Listener {

--- a/LandLord-core/src/main/java/biz/princeps/lib/gui/simple/Icon.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/gui/simple/Icon.java
@@ -11,9 +11,8 @@ import java.util.List;
  */
 public class Icon {
 
-    public ItemStack itemStack;
-
     public final List<Action> clickActions = new ArrayList<>();
+    public ItemStack itemStack;
 
     public Icon(ItemStack itemStack) {
         this.itemStack = itemStack;
@@ -35,14 +34,14 @@ public class Icon {
         return this;
     }
 
+    public List<String> getLore() {
+        return itemStack.getItemMeta().getLore();
+    }
+
     public Icon setLore(List<String> lore) {
         ItemMeta meta = itemStack.getItemMeta();
         meta.setLore(lore);
         itemStack.setItemMeta(meta);
         return this;
-    }
-
-    public List<String> getLore() {
-        return itemStack.getItemMeta().getLore();
     }
 }

--- a/LandLord-core/src/main/java/biz/princeps/lib/item/AbstractItem.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/item/AbstractItem.java
@@ -17,10 +17,10 @@ import org.bukkit.inventory.meta.ItemMeta;
  */
 public abstract class AbstractItem {
 
+    protected final String name;
+    private final boolean breakBlocks;
     private ItemStack stack;
     private boolean glowing;
-    private final boolean breakBlocks;
-    protected final String name;
 
     /**
      * Used to initially create a custom item stack
@@ -35,6 +35,10 @@ public abstract class AbstractItem {
         this.stack = PrincepsLib.crossVersion().addNBTTag(stack, "customItemName", name);
         setGlowing(glowing);
         this.breakBlocks = breakBlocks;
+    }
+
+    public static boolean isCustomItem(ItemStack stack) {
+        return PrincepsLib.crossVersion().hasNBTTag(stack, "customItem");
     }
 
     public void give(Player p) {
@@ -75,9 +79,5 @@ public abstract class AbstractItem {
 
     public boolean canBreakBlocks() {
         return breakBlocks;
-    }
-
-    public static boolean isCustomItem(ItemStack stack) {
-        return PrincepsLib.crossVersion().hasNBTTag(stack, "customItem");
     }
 }

--- a/LandLord-core/src/main/java/biz/princeps/lib/item/ItemManager.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/item/ItemManager.java
@@ -25,6 +25,15 @@ public class ItemManager {
         new ItemActionListener(this);
     }
 
+    public static ItemStack stack(String string) {
+        try {
+            Material material = Material.valueOf(string.toUpperCase());
+            return new ItemStack(material);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
     public void registerItem(String name, Class<? extends AbstractItem> item) {
         items.put(name, item);
     }
@@ -40,14 +49,5 @@ public class ItemManager {
             EldoUtilities.logger().log(Level.WARNING, "Custom item must implement empty constructor: " + e);
         }
         return null;
-    }
-
-    public static ItemStack stack(String string) {
-        try {
-            Material material = Material.valueOf(string.toUpperCase());
-            return new ItemStack(material);
-        } catch (NumberFormatException ex) {
-            return null;
-        }
     }
 }

--- a/LandLord-core/src/main/java/biz/princeps/lib/storage/Datastorage.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/storage/Datastorage.java
@@ -2,7 +2,7 @@ package biz.princeps.lib.storage;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.sql.Connection;
@@ -19,10 +19,10 @@ import java.util.function.Consumer;
  */
 public class Datastorage {
 
-    protected final JavaPlugin plugin;
+    protected final Plugin plugin;
     protected final HikariDataSource ds;
 
-    public Datastorage(JavaPlugin plugin, String hostname, String port, String username, String password, String database) {
+    public Datastorage(Plugin plugin, String hostname, String port, String username, String password, String database) {
         this.plugin = plugin;
 
         HikariConfig hikariConfig = new HikariConfig();

--- a/LandLord-latest/src/main/java/biz/princeps/landlord/LandLord.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/LandLord.java
@@ -42,7 +42,7 @@ public class LandLord extends ALandLord {
         this.mobManager = new MobsManager(this);
 
         if (getConfig().getString("Regeneration.provider", "default").equalsIgnoreCase("wg")) {
-            File folder = new File(getPlugin().getDataFolder(), "chunksaves");
+            File folder = new File(getDataFolder(), "chunksaves");
             folder.mkdir();
             this.regenerationManager = new WGRegenerator(this);
             new WGRegenListener(this);

--- a/LandLord-latest/src/main/java/biz/princeps/landlord/OwnedLand.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/OwnedLand.java
@@ -205,7 +205,7 @@ public class OwnedLand extends AOwnedLand {
         for (String s : rawList) {
             Flag<StateFlag.State> flag = getWGFlag(s.toUpperCase());
             if (!(flag instanceof StateFlag)) {
-                plugin.getPlugin().getLogger().warning("Only stateflags are supported!");
+                plugin.getLogger().warning("Only stateflags are supported!");
                 return;
             }
             region.setFlag(flag.getRegionGroupFlag(), RegionGroup.MEMBERS);

--- a/LandLord-latest/src/main/java/biz/princeps/landlord/listener/WGRegenListener.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/listener/WGRegenListener.java
@@ -60,7 +60,7 @@ public class WGRegenListener extends BasicListener {
             worldEditException.printStackTrace();
         }
 
-        File file = new File(new File(plugin.getPlugin().getDataFolder(), "chunksaves"), e.getLand().getName());
+        File file = new File(new File(plugin.getDataFolder(), "chunksaves"), e.getLand().getName());
 
         try (ClipboardWriter writer = BuiltInClipboardFormat.SPONGE_SCHEMATIC.getWriter(new FileOutputStream(file))) {
             writer.write(clipboard);

--- a/LandLord-latest/src/main/java/biz/princeps/landlord/manager/WorldGuardManager.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/manager/WorldGuardManager.java
@@ -173,7 +173,7 @@ public class WorldGuardManager extends AWorldGuardManager {
             public void run() {
                 getRegionManager(world).removeRegion(regionname);
             }
-        }.runTaskAsynchronously(plugin.getPlugin());
+        }.runTaskAsynchronously(plugin);
     }
 
     /**

--- a/LandLord-latest/src/main/java/biz/princeps/landlord/regenerators/WGRegenerator.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/regenerators/WGRegenerator.java
@@ -48,7 +48,7 @@ public class WGRegenerator implements IRegenerationManager {
             }
         }
 
-        File file = new File(new File(plugin.getPlugin().getDataFolder(), "chunksaves"), landName);
+        File file = new File(new File(plugin.getDataFolder(), "chunksaves"), landName);
 
         if (file.exists()) {
             ClipboardFormat format = BuiltInClipboardFormat.SPONGE_SCHEMATIC;

--- a/LandLord-legacy/src/main/java/biz/princeps/landlord/manager/WorldGuardManager.java
+++ b/LandLord-legacy/src/main/java/biz/princeps/landlord/manager/WorldGuardManager.java
@@ -169,7 +169,7 @@ public class WorldGuardManager extends AWorldGuardManager {
             public void run() {
                 getRegionManager(world).removeRegion(regionname);
             }
-        }.runTaskAsynchronously(plugin.getPlugin());
+        }.runTaskAsynchronously(plugin);
     }
 
     /**

--- a/buildSrc/src/main/kotlin/biz.princeps.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/biz.princeps.java-conventions.gradle.kts
@@ -27,7 +27,7 @@ allprojects {
     java {
         withSourcesJar()
         withJavadocJar()
-        sourceCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
     }
 }
 


### PR DESCRIPTION
Make ILandLord a Plugin
This allows us to not make those dirty ILanlord#getPlugin() calls and allows us to directly call plugin methods.

Update gradle to 7.3 and java version to 11

Replace JavaPlugin with Plugin interface everywhere

None of these changes is breaking for now except the java version bump, but this is okay.