### PR TITLE
fix: correctly calculate location from chunk coords

### DIFF
--- a/LandLord-core/src/main/java/biz/princeps/landlord/protection/AWorldGuardManager.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/protection/AWorldGuardManager.java
@@ -224,7 +224,7 @@ public abstract class AWorldGuardManager implements IWorldGuardManager {
 
     @Override
     public IOwnedLand[] getSurroundings(Chunk chunk) {
-        return getSurroundings(new Location(chunk.getWorld(), (chunk.getX() << 4) + 1, 1, chunk.getZ() << 4 + 1));
+        return getSurroundings(new Location(chunk.getWorld(), chunk.getX() << 4, 1, chunk.getZ() << 4));
     }
 
     @Override

--- a/LandLord-core/src/main/java/biz/princeps/landlord/protection/AWorldGuardManager.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/protection/AWorldGuardManager.java
@@ -245,7 +245,7 @@ public abstract class AWorldGuardManager implements IWorldGuardManager {
 
     @Override
     public IOwnedLand[] getSurroundingsOwner(Chunk chunk, UUID owner) {
-        return getSurroundingsOwner(new Location(chunk.getWorld(), (chunk.getX() << 4) + 1, 1, (chunk.getZ() << 4) + 1), owner);
+        return getSurroundingsOwner(new Location(chunk.getWorld(), chunk.getX() << 4, 1, chunk.getZ() << 4), owner);
     }
 
     @Override


### PR DESCRIPTION
`<<` has a lower precedence than `+`, so only the expression with parentheses was correct. As the `+ 1` is not needed, we can just drop it alltogether and avoid further issues here.