### PR TITLE
fix: enquote version to enforce type

### DIFF
--- a/LandLord-latest/src/main/resources/plugin.yml
+++ b/LandLord-latest/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Landlord
-version: ${version}
+version: "${version}"
 main: biz.princeps.landlord.LandLord
 authors: [ SpatiumPrinceps, Aurelien30000, SirYwell, RainbowDashLabs ]
 website: https://www.spigotmc.org/resources/44398/

--- a/LandLord-legacy/src/main/resources/plugin.yml
+++ b/LandLord-legacy/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Landlord
-version: ${version}
+version: "${version}"
 main: biz.princeps.landlord.LandLord
 authors: [ SpatiumPrinceps, Aurelien30000, SirYwell, RainbowDashLabs ]
 website: https://www.spigotmc.org/resources/44398/


### PR DESCRIPTION
Currently, the version number gets parsed as floating point value, causing trailing zeroes being truncated. This is for example the case for `4.360` which becomes `4.36`