### PR TITLE
``Bukkit`` performance improvements/cleanup before v5.

### DIFF
--- a/LandLord-api/src/main/java/biz/princeps/landlord/api/IMaterialsManager.java
+++ b/LandLord-api/src/main/java/biz/princeps/landlord/api/IMaterialsManager.java
@@ -1,6 +1,7 @@
 package biz.princeps.landlord.api;
 
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.UUID;
@@ -27,5 +28,22 @@ public interface IMaterialsManager {
     Material getFireCharge();
 
     ItemStack getGreyStainedGlass();
+
+    Material getNetherGrass();
+
+    Material getEnderGrass();
+
+    default Material getWorldGrass(World world) {
+        switch (world.getEnvironment()) {
+            case NORMAL:
+                return getGrass();
+            case NETHER:
+                return getNetherGrass();
+            case THE_END:
+                return getEnderGrass();
+            default:
+                return Material.BARRIER;
+        }
+    }
 
 }

--- a/LandLord-api/src/main/java/biz/princeps/landlord/api/events/LandManageEvent.java
+++ b/LandLord-api/src/main/java/biz/princeps/landlord/api/events/LandManageEvent.java
@@ -1,6 +1,7 @@
 package biz.princeps.landlord.api.events;
 
 import biz.princeps.landlord.api.IOwnedLand;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -23,9 +24,8 @@ public class LandManageEvent extends Event {
     private final Object oldValue;
     private final Object newValue;
 
-
     public LandManageEvent(Player player, IOwnedLand land, String flagChanged, Object oldValue, Object newValue) {
-        super(true);
+        super(!Bukkit.isPrimaryThread());
         this.player = player;
         this.land = land;
         this.flagChanged = flagChanged;

--- a/LandLord-api/src/main/java/biz/princeps/landlord/api/events/LandManageEvent.java
+++ b/LandLord-api/src/main/java/biz/princeps/landlord/api/events/LandManageEvent.java
@@ -25,6 +25,7 @@ public class LandManageEvent extends Event {
 
 
     public LandManageEvent(Player player, IOwnedLand land, String flagChanged, Object oldValue, Object newValue) {
+        super(true);
         this.player = player;
         this.land = land;
         this.flagChanged = flagChanged;

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/Landlordbase.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/Landlordbase.java
@@ -142,8 +142,7 @@ public class Landlordbase extends MainCommand {
                         if (Options.enabled_map()) {
                             tabReturn.add(subCommand.getName());
                         }
-                    } else if (subCommand instanceof Shop || subCommand instanceof Claims
-                            || subCommand instanceof GiveClaims) {
+                    } else if (subCommand instanceof Shop || subCommand instanceof GiveClaims) {
                         if (Options.enabled_shop()) {
                             tabReturn.add(subCommand.getName());
                         }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/AdminTeleport.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/AdminTeleport.java
@@ -58,7 +58,7 @@ public class AdminTeleport extends LandlordCommand {
                             lm.getRawString("Commands.AdminTp.guiHeader").replace("%player%", target));
 
                     for (IOwnedLand land : lands) {
-                        landGui.addIcon(new Icon(new ItemStack(plugin.getMaterialsManager().getGrass()))
+                        landGui.addIcon(new Icon(new ItemStack(plugin.getMaterialsManager().getWorldGrass(land.getWorld())))
                                 .setName(land.getName())
                                 .addClickAction((p) -> {
                                             Location toTp = land.getALocation();

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/Addfriend.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/Addfriend.java
@@ -74,7 +74,7 @@ public class Addfriend extends LandlordCommand {
                                     "FRIENDS", oldFriends, land.getMembersString());
                             plugin.getServer().getPluginManager().callEvent(landManageEvent);
                         }
-                    }.runTask(plugin);
+                    }.runTaskAsynchronously(plugin);
 
                     lm.sendMessage(player, lm.getString(player, "Commands.Addfriend.success")
                             .replace("%players%", playerName));

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/AddfriendAll.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/AddfriendAll.java
@@ -64,14 +64,10 @@ public class AddfriendAll extends LandlordCommand {
                                 String oldfriends = ol.getMembersString();
                                 ol.addFriend(offline.getUuid());
                                 count++;
-                                new BukkitRunnable() {
-                                    @Override
-                                    public void run() {
-                                        LandManageEvent landManageEvent = new LandManageEvent(player, ol,
-                                                "FRIENDS", oldfriends, ol.getMembersString());
-                                        plugin.getServer().getPluginManager().callEvent(landManageEvent);
-                                    }
-                                }.runTask(plugin);
+
+                                LandManageEvent landManageEvent = new LandManageEvent(player, ol,
+                                        "FRIENDS", oldfriends, ol.getMembersString());
+                                plugin.getServer().getPluginManager().callEvent(landManageEvent);
                             }
                         }
 

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/MultiAddfriend.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/MultiAddfriend.java
@@ -77,14 +77,10 @@ public class MultiAddfriend extends LandlordCommand {
                                 String oldfriends = ol.getMembersString();
                                 ol.addFriend(offline.getUuid());
                                 count++;
-                                new BukkitRunnable() {
-                                    @Override
-                                    public void run() {
-                                        LandManageEvent landManageEvent = new LandManageEvent(player, ol,
-                                                "FRIENDS", oldfriends, ol.getMembersString());
-                                        plugin.getServer().getPluginManager().callEvent(landManageEvent);
-                                    }
-                                }.runTask(plugin);
+
+                                LandManageEvent landManageEvent = new LandManageEvent(player, ol,
+                                        "FRIENDS", oldfriends, ol.getMembersString());
+                                plugin.getServer().getPluginManager().callEvent(landManageEvent);
                             }
                         }
 

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/MultiRemovefriend.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/MultiRemovefriend.java
@@ -77,14 +77,10 @@ public class MultiRemovefriend extends LandlordCommand {
                                 String oldvalue = ol.getMembersString();
                                 ol.removeFriend(offline.getUuid());
                                 count++;
-                                new BukkitRunnable() {
-                                    @Override
-                                    public void run() {
-                                        LandManageEvent landManageEvent = new LandManageEvent(player, ol,
-                                                "FRIENDS", oldvalue, ol.getMembersString());
-                                        plugin.getServer().getPluginManager().callEvent(landManageEvent);
-                                    }
-                                }.runTask(plugin);
+
+                                LandManageEvent landManageEvent = new LandManageEvent(player, ol,
+                                        "FRIENDS", oldvalue, ol.getMembersString());
+                                plugin.getServer().getPluginManager().callEvent(landManageEvent);
                             }
                         }
 

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/Unfriend.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/Unfriend.java
@@ -83,7 +83,7 @@ public class Unfriend extends LandlordCommand {
                                     "FRIENDS", old, land.getMembersString());
                             plugin.getServer().getPluginManager().callEvent(landManageEvent);
                         }
-                    }.runTask(plugin);
+                    }.runTaskAsynchronously(plugin);
 
                     lm.sendMessage(player, lm.getString(player, "Commands.Unfriend.success")
                             .replace("%players%", playerName));

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/UnfriendAll.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/friends/UnfriendAll.java
@@ -64,14 +64,10 @@ public class UnfriendAll extends LandlordCommand {
                                 String oldvalue = ol.getMembersString();
                                 ol.removeFriend(offline.getUuid());
                                 count++;
-                                new BukkitRunnable() {
-                                    @Override
-                                    public void run() {
-                                        LandManageEvent landManageEvent = new LandManageEvent(player, ol,
-                                                "FRIENDS", oldvalue, ol.getMembersString());
-                                        plugin.getServer().getPluginManager().callEvent(landManageEvent);
-                                    }
-                                }.runTask(plugin);
+
+                                LandManageEvent landManageEvent = new LandManageEvent(player, ol,
+                                        "FRIENDS", oldvalue, ol.getMembersString());
+                                plugin.getServer().getPluginManager().callEvent(landManageEvent);
                             }
                         }
 

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/ListLands.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/ListLands.java
@@ -137,7 +137,7 @@ public class ListLands extends LandlordCommand {
                             }
                         }
 
-                        Icon icon = new Icon(new ItemStack(plugin.getMaterialsManager().getGrass()));
+                        Icon icon = new Icon(new ItemStack(plugin.getMaterialsManager().getWorldGrass(land.getWorld())));
                         icon.setName(lm.getRawString("Commands.ListLands.gui.itemname")
                                 .replace("%name%", land.getName()));
                         icon.setLore(lore);

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Manage.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Manage.java
@@ -13,6 +13,7 @@ import biz.princeps.lib.exception.ArgumentsOutOfBoundsException;
 import com.google.common.collect.Sets;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -130,7 +131,6 @@ public class Manage extends LandlordCommand {
         }
     }
 
-
     private void setGreet(Player player, String[] args, List<IOwnedLand> lands, int casy) {
         if (lands.size() == 0 || lands.get(0) == null) {
             lm.sendMessage(player, lm.getString(player, "Commands.Manage.notOwnFreeLand"));
@@ -149,12 +149,20 @@ public class Manage extends LandlordCommand {
         newmsg = newmsg.replace("%owner%", player.getName());
 
         for (IOwnedLand region : lands) {
-            LandManageEvent landManageEvent = new LandManageEvent(player, region,
-                    "GREET_MESSAGE", region.getGreetMessage(), newmsg);
-            plugin.getServer().getPluginManager().callEvent(landManageEvent);
-
             region.setGreetMessage(newmsg);
         }
+
+        String finalNewmsg = newmsg;
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (IOwnedLand region : lands) {
+                    LandManageEvent landManageEvent = new LandManageEvent(player, region,
+                            "GREET_MESSAGE", region.getGreetMessage(), finalNewmsg);
+                    plugin.getServer().getPluginManager().callEvent(landManageEvent);
+                }
+            }
+        }.runTaskAsynchronously(plugin);
 
         lm.sendMessage(player, lm.getString(player, "Commands.Manage.SetGreet.successful")
                 .replace("%msg%", newmsg));
@@ -178,12 +186,21 @@ public class Manage extends LandlordCommand {
         newmsg = newmsg.replace("%owner%", player.getName());
 
         for (IOwnedLand region : lands) {
-            LandManageEvent landManageEvent = new LandManageEvent(player, region,
-                    "FAREWELL_MESSAGE", region.getFarewellMessage(), newmsg);
-            plugin.getServer().getPluginManager().callEvent(landManageEvent);
-
             region.setFarewellMessage(newmsg);
         }
+
+        String finalNewmsg = newmsg;
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (IOwnedLand region : lands) {
+                    LandManageEvent landManageEvent = new LandManageEvent(player, region,
+                            "FAREWELL_MESSAGE", region.getFarewellMessage(), finalNewmsg);
+                    plugin.getServer().getPluginManager().callEvent(landManageEvent);
+
+                }
+            }
+        }.runTaskAsynchronously(plugin);
 
         lm.sendMessage(player, lm.getString(player, "Commands.Manage.SetFarewell.successful")
                 .replace("%msg%", newmsg));

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/MultiListLands.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/MultiListLands.java
@@ -144,7 +144,7 @@ public class MultiListLands extends LandlordCommand {
                             }
                         }
 
-                        Icon icon = new Icon(new ItemStack(plugin.getMaterialsManager().getGrass()));
+                        Icon icon = new Icon(new ItemStack(plugin.getMaterialsManager().getWorldGrass(land.getWorld())));
                         icon.setName(lm.getRawString("Commands.MultiListLands.gui.itemname")
                                 .replace("%name%", land.getName()));
                         icon.setLore(lore);

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Regenerate.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Regenerate.java
@@ -81,7 +81,7 @@ public class Regenerate extends LandlordCommand {
                                             null, "REGENERATE", "REGENERATE");
                                     plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                 }
-                            }.runTask(plugin);
+                            }.runTaskAsynchronously(plugin);
 
                             plugin.getRegenerationManager().regenerateChunk(finalLand.getALocation());
                             lm.sendMessage(player, lm.getString(player, "Commands.Regenerate.success")

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Regenerate.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Regenerate.java
@@ -11,7 +11,6 @@ import biz.princeps.lib.command.Properties;
 import biz.princeps.lib.gui.ConfirmationGUI;
 import com.google.common.collect.Sets;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 
 
 /**
@@ -74,14 +73,9 @@ public class Regenerate extends LandlordCommand {
                             }
                         }
                         if (flag) {
-                            new BukkitRunnable() {
-                                @Override
-                                public void run() {
-                                    LandManageEvent landManageEvent = new LandManageEvent(player, finalLand,
-                                            null, "REGENERATE", "REGENERATE");
-                                    plugin.getServer().getPluginManager().callEvent(landManageEvent);
-                                }
-                            }.runTaskAsynchronously(plugin);
+                            LandManageEvent landManageEvent = new LandManageEvent(player, finalLand,
+                                    null, "REGENERATE", "REGENERATE");
+                            plugin.getServer().getPluginManager().callEvent(landManageEvent);
 
                             plugin.getRegenerationManager().regenerateChunk(finalLand.getALocation());
                             lm.sendMessage(player, lm.getString(player, "Commands.Regenerate.success")

--- a/LandLord-core/src/main/java/biz/princeps/landlord/guis/AManage.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/guis/AManage.java
@@ -204,14 +204,9 @@ public class AManage extends AbstractGUI {
 
                                 landFlag.toggleFriends();
 
-                                new BukkitRunnable() {
-                                    @Override
-                                    public void run() {
-                                        LandManageEvent landManageEvent = new LandManageEvent(player, land,
-                                                landFlag.getName(), !landFlag.getFriendStatus(), landFlag.getFriendStatus());
-                                        plugin.getServer().getPluginManager().callEvent(landManageEvent);
-                                    }
-                                }.runTask(plugin);
+                                LandManageEvent landManageEvent = new LandManageEvent(player, land,
+                                        landFlag.getName(), !landFlag.getFriendStatus(), landFlag.getFriendStatus());
+                                plugin.getServer().getPluginManager().callEvent(landManageEvent);
                             }
                         }
                     }
@@ -237,14 +232,9 @@ public class AManage extends AbstractGUI {
 
                                 landFlag.toggleAll();
 
-                                new BukkitRunnable() {
-                                    @Override
-                                    public void run() {
-                                        LandManageEvent landManageEvent = new LandManageEvent(player, land,
-                                                landFlag.getName(), !landFlag.getFriendStatus(), landFlag.getFriendStatus());
-                                        plugin.getServer().getPluginManager().callEvent(landManageEvent);
-                                    }
-                                }.runTask(plugin);
+                                LandManageEvent landManageEvent = new LandManageEvent(player, land,
+                                        landFlag.getName(), !landFlag.getFriendStatus(), landFlag.getFriendStatus());
+                                plugin.getServer().getPluginManager().callEvent(landManageEvent);
                             }
                         }
                     }
@@ -339,6 +329,46 @@ public class AManage extends AbstractGUI {
                     player.hasPermission("landlord.player.manage.spreadfriends") && manageMode != ManageMode.ONE;
             MultiPagedGUI friendsGui = new MultiPagedGUI(plugin, player, (int) Math.ceil((double) friends.size() / 9.0),
                     lm.getRawString("Commands.Manage.ManageFriends.title"), new ArrayList<>(), this) {
+
+                @Override
+                protected void create() {
+                    String rawTitle = lm.getRawString("Commands.Manage.ManageFriends.unfriend");
+
+                    for (UUID id : friends) {
+                        OfflinePlayer op = plugin.getServer().getOfflinePlayer(id);
+                        Icon friend = new Icon(mats.getPlayerHead(id));
+                        String name = (op != null && op.getName() != null ? op.getName() : "OfflinePlayer");
+                        String confititle = rawTitle.replace("%player%", name);
+                        friend.setName(name);
+                        friend.setLore(formatFriendsSegment(id));
+                        friend.addClickAction((player) -> {
+                            ConfirmationGUI confirmationGUI = new ConfirmationGUI(plugin, this.player,
+                                    confititle,
+                                    (p) -> {
+                                        this.removeIcon(friend);
+
+                                        for (IOwnedLand region : regions) {
+                                            plugin.getServer().dispatchCommand(player, PrincepsLib.getCommandManager()
+                                                    .getCommand(Landlordbase.class).getCommandString(Unfriend.class)
+                                                    .substring(1) + " " + name + " " + region.getName());
+                                        }
+                                        player.closeInventory();
+                                        this.display();
+                                    },
+                                    (p) -> {
+                                        player.closeInventory();
+                                        this.display();
+                                    }, this);
+                            confirmationGUI.setConfirm(lm.getRawString("Confirmation.accept"));
+                            confirmationGUI.setDecline(lm.getRawString("Confirmation.decline"));
+                            confirmationGUI.display();
+                        });
+                        this.addIcon(friend);
+                    }
+
+                    super.create();
+                }
+
                 @Override
                 protected void generateStaticIcons() {
                     if (canSpread) {
@@ -364,14 +394,9 @@ public class AManage extends AbstractGUI {
                                                 if (!region.isFriend(defaultFriend)) region.addFriend(defaultFriend);
                                             }
 
-                                            new BukkitRunnable() {
-                                                @Override
-                                                public void run() {
-                                                    LandManageEvent landManageEvent = new LandManageEvent(player, region,
-                                                            "FRIENDS", oldfriends, region.getMembersString());
-                                                    plugin.getServer().getPluginManager().callEvent(landManageEvent);
-                                                }
-                                            }.runTask(plugin);
+                                            LandManageEvent landManageEvent = new LandManageEvent(player, region,
+                                                    "FRIENDS", oldfriends, region.getMembersString());
+                                            plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                         }
                                     }
                                 }.runTaskAsynchronously(plugin));
@@ -381,39 +406,6 @@ public class AManage extends AbstractGUI {
                 }
             };
 
-            String rawTitle = lm.getRawString("Commands.Manage.ManageFriends.unfriend");
-
-            for (UUID id : friends) {
-                OfflinePlayer op = plugin.getServer().getOfflinePlayer(id);
-                Icon friend = new Icon(mats.getPlayerHead(id));
-                String name = (op != null && op.getName() != null ? op.getName() : "OfflinePlayer");
-                String confititle = rawTitle.replace("%player%", name);
-                friend.setName(name);
-                friend.setLore(formatFriendsSegment(id));
-                friend.addClickAction((player) -> {
-                    ConfirmationGUI confirmationGUI = new ConfirmationGUI(plugin, this.player,
-                            confititle,
-                            (p) -> {
-                                friendsGui.removeIcon(friend);
-
-                                for (IOwnedLand region : regions) {
-                                    plugin.getServer().dispatchCommand(player, PrincepsLib.getCommandManager()
-                                            .getCommand(Landlordbase.class).getCommandString(Unfriend.class)
-                                            .substring(1) + " " + name + " " + region.getName());
-                                }
-                                player.closeInventory();
-                                friendsGui.display();
-                            },
-                            (p) -> {
-                                player.closeInventory();
-                                friendsGui.display();
-                            }, friendsGui);
-                    confirmationGUI.setConfirm(lm.getRawString("Confirmation.accept"));
-                    confirmationGUI.setDecline(lm.getRawString("Confirmation.decline"));
-                    confirmationGUI.display();
-                });
-                friendsGui.addIcon(friend);
-            }
             int friendPosition = position;
             icon.addClickAction((p) -> {
                 friendsGui.generateAsync().display();
@@ -556,26 +548,16 @@ public class AManage extends AbstractGUI {
                                     if (defaultFlag.getFriendStatus() != landFlag.getFriendStatus()) {
                                         landFlag.toggleFriends();
 
-                                        new BukkitRunnable() {
-                                            @Override
-                                            public void run() {
-                                                LandManageEvent landManageEvent = new LandManageEvent(player, land,
-                                                        landFlag.getName(), !landFlag.getFriendStatus(), landFlag.getFriendStatus());
-                                                plugin.getServer().getPluginManager().callEvent(landManageEvent);
-                                            }
-                                        }.runTask(plugin);
+                                        LandManageEvent landManageEvent = new LandManageEvent(player, land,
+                                                landFlag.getName(), !landFlag.getFriendStatus(), landFlag.getFriendStatus());
+                                        plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                     }
                                     if (defaultFlag.getAllStatus() != landFlag.getAllStatus()) {
                                         landFlag.toggleAll();
 
-                                        new BukkitRunnable() {
-                                            @Override
-                                            public void run() {
-                                                LandManageEvent landManageEvent = new LandManageEvent(player, land,
-                                                        landFlag.getName(), !landFlag.getAllStatus(), landFlag.getAllStatus());
-                                                plugin.getServer().getPluginManager().callEvent(landManageEvent);
-                                            }
-                                        }.runTask(plugin);
+                                        LandManageEvent landManageEvent = new LandManageEvent(player, land,
+                                                landFlag.getName(), !landFlag.getAllStatus(), landFlag.getAllStatus());
+                                        plugin.getServer().getPluginManager().callEvent(landManageEvent);
                                     }
                                 }
                             }
@@ -623,13 +605,13 @@ public class AManage extends AbstractGUI {
         OfflinePlayer op = plugin.getServer().getOfflinePlayer(id);
         List<String> toReturn = new ArrayList<>();
 
-        IPlayer offline = plugin.getPlayerManager().getOfflineSync(id);
         List<String> stringList = lm.getStringList("Commands.Manage.ManageFriends.friendSegment");
         String lastseen;
 
         if (op.isOnline()) {
             lastseen = lm.getRawString("Commands.Info.online");
         } else {
+            IPlayer offline = plugin.getPlayerManager().getOfflineSync(id);
             if (offline != null) {
                 lastseen = offline.getLastSeen().toString();
             } else {

--- a/LandLord-latest/build.gradle.kts
+++ b/LandLord-latest/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     implementation(project(":LandLord-core"))
-    compileOnly("org.spigotmc:spigot-api:1.19-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.18.2-R0.1-SNAPSHOT")
     compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.2.7-SNAPSHOT")
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.5-SNAPSHOT")
     compileOnly("io.papermc:paperlib:1.0.7")

--- a/LandLord-latest/src/main/java/biz/princeps/landlord/LLFlag.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/LLFlag.java
@@ -3,6 +3,7 @@ package biz.princeps.landlord;
 import biz.princeps.landlord.api.ILLFlag;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.RegionGroup;
+import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import org.bukkit.Material;
@@ -25,27 +26,25 @@ public class LLFlag implements ILLFlag {
         this.flag = flag;
         this.mat = mat;
 
-        RegionGroup regionGroupFlag = (RegionGroup) pr.getFlags().get(flag.getRegionGroupFlag());
+        RegionGroupFlag regionGroupFlag = flag.getRegionGroupFlag();
+        RegionGroup regionGroup = (RegionGroup) pr.getFlags().get(regionGroupFlag);
         StateFlag.State value = (StateFlag.State) pr.getFlags().get(flag);
-        setStatus(regionGroupFlag, value);
+        setStatus(regionGroup == null ? regionGroupFlag.getDefault() : regionGroup, value == null ? flag.getDefault() : value);
     }
 
-    void setStatus(RegionGroup grp, Object state) {
+    private void setStatus(RegionGroup grp, StateFlag.State state) {
         if (grp == RegionGroup.MEMBERS && state == StateFlag.State.ALLOW ||
                 grp == RegionGroup.NON_MEMBERS && state == StateFlag.State.DENY) {
             friendStatus = true;
             allStatus = false;
-            // System.out.println("10");
         }
         if (grp == RegionGroup.ALL && state == StateFlag.State.ALLOW) {
             friendStatus = true;
             allStatus = true;
-            // System.out.println("11");
         }
         if (grp == RegionGroup.NON_OWNERS && state == StateFlag.State.DENY) {
             friendStatus = false;
             allStatus = false;
-            // System.out.println("00");
         }
     }
 

--- a/LandLord-latest/src/main/java/biz/princeps/landlord/OwnedLand.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/OwnedLand.java
@@ -21,8 +21,10 @@ import org.bukkit.World;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Project: LandLord
@@ -30,6 +32,8 @@ import java.util.UUID;
  * Date: 06-05-19
  */
 public class OwnedLand extends AOwnedLand {
+
+    private static final Map<String, Flag<StateFlag.State>> FLAGS_CACHE = new ConcurrentHashMap<>();
 
     private final ProtectedRegion region;
     private final FlagRegistry flagRegistry = WorldGuard.getInstance().getFlagRegistry();
@@ -325,7 +329,7 @@ public class OwnedLand extends AOwnedLand {
     }
 
     private Flag<StateFlag.State> getWGFlag(String flagName) {
-        return (Flag<StateFlag.State>) Flags.fuzzyMatchFlag(flagRegistry, flagName);
+        return FLAGS_CACHE.computeIfAbsent(flagName, name -> (Flag<StateFlag.State>) Flags.fuzzyMatchFlag(flagRegistry, name));
     }
 
 }

--- a/LandLord-latest/src/main/java/biz/princeps/landlord/manager/MaterialsManager.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/manager/MaterialsManager.java
@@ -64,4 +64,14 @@ public class MaterialsManager implements IMaterialsManager {
     public ItemStack getGreyStainedGlass() {
         return new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
     }
+
+    @Override
+    public Material getNetherGrass() {
+        return Material.CRIMSON_NYLIUM;
+    }
+
+    @Override
+    public Material getEnderGrass() {
+        return Material.END_STONE;
+    }
 }

--- a/LandLord-legacy/src/main/java/biz/princeps/landlord/LLFlag.java
+++ b/LandLord-legacy/src/main/java/biz/princeps/landlord/LLFlag.java
@@ -3,6 +3,7 @@ package biz.princeps.landlord;
 import biz.princeps.landlord.api.ILLFlag;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.RegionGroup;
+import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import org.bukkit.Material;
@@ -25,27 +26,25 @@ public class LLFlag implements ILLFlag {
         this.flag = flag;
         this.mat = mat;
 
-        RegionGroup regionGroupFlag = (RegionGroup) pr.getFlags().get(flag.getRegionGroupFlag());
+        RegionGroupFlag regionGroupFlag = flag.getRegionGroupFlag();
+        RegionGroup regionGroup = (RegionGroup) pr.getFlags().get(regionGroupFlag);
         StateFlag.State value = (StateFlag.State) pr.getFlags().get(flag);
-        setStatus(regionGroupFlag, value);
+        setStatus(regionGroup == null ? regionGroupFlag.getDefault() : regionGroup, value == null ? flag.getDefault() : value);
     }
 
-    void setStatus(RegionGroup grp, Object state) {
+    private void setStatus(RegionGroup grp, StateFlag.State state) {
         if (grp == RegionGroup.MEMBERS && state == StateFlag.State.ALLOW ||
                 grp == RegionGroup.NON_MEMBERS && state == StateFlag.State.DENY) {
             friendStatus = true;
             allStatus = false;
-            // System.out.println("10");
         }
         if (grp == RegionGroup.ALL && state == StateFlag.State.ALLOW) {
             friendStatus = true;
             allStatus = true;
-            // System.out.println("11");
         }
         if (grp == RegionGroup.NON_OWNERS && state == StateFlag.State.DENY) {
             friendStatus = false;
             allStatus = false;
-            // System.out.println("00");
         }
     }
 

--- a/LandLord-legacy/src/main/java/biz/princeps/landlord/OwnedLand.java
+++ b/LandLord-legacy/src/main/java/biz/princeps/landlord/OwnedLand.java
@@ -21,8 +21,10 @@ import org.bukkit.entity.EntityType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Project: LandLord
@@ -30,6 +32,8 @@ import java.util.UUID;
  * Date: 06-05-19
  */
 public class OwnedLand extends AOwnedLand {
+
+    private static final Map<String, Flag<StateFlag.State>> FLAGS_CACHE = new ConcurrentHashMap<>();
 
     private final ProtectedRegion region;
     private final FlagRegistry flagRegistry = WorldGuardPlugin.inst().getFlagRegistry();
@@ -325,7 +329,7 @@ public class OwnedLand extends AOwnedLand {
     }
 
     private Flag<StateFlag.State> getWGFlag(String flagName) {
-        return (Flag<StateFlag.State>) DefaultFlag.fuzzyMatchFlag(flagRegistry, flagName);
+        return FLAGS_CACHE.computeIfAbsent(flagName, name -> (Flag<StateFlag.State>) DefaultFlag.fuzzyMatchFlag(flagRegistry, name));
     }
 
 }

--- a/LandLord-legacy/src/main/java/biz/princeps/landlord/manager/MaterialsManager.java
+++ b/LandLord-legacy/src/main/java/biz/princeps/landlord/manager/MaterialsManager.java
@@ -65,5 +65,13 @@ public class MaterialsManager implements IMaterialsManager {
         return new ItemStack(Material.STAINED_GLASS_PANE, 1, (short) 7);
     }
 
+    @Override
+    public Material getNetherGrass() {
+        return Material.NETHERRACK;
+    }
 
+    @Override
+    public Material getEnderGrass() {
+        return Material.ENDER_STONE;
+    }
 }


### PR DESCRIPTION
_Partly related to discord's conversation about dynmap extension issues and crash._

- Maintains a Map to fetch more efficiently flags from their id.
- Calls heavy manage event asynchronously _(iirc, former Bukkit like 1.13 forced us to switch back to a full sync management, this is no longer the cas and we don't really care about 1.15-/1.16-)_.
- Seperates lands' icon in lists according to their dimension _(somehow breaking for older versions, configurable items is a TODO, I kept the things simple)_.
- Fix default flag value visibility with non-registered flags in a land. For example, when a custom flag is added to the plugin, lands claimed before this addition do not have the flag registered until a modification is done with the `/land manage`. However, it's real default value must be shown (~allowed).
- Removes some useless debug comments.