### PR TITLE
Port master improvements

### DIFF
--- a/LandLord-api/src/main/java/biz/princeps/landlord/api/IMaterialsManager.java
+++ b/LandLord-api/src/main/java/biz/princeps/landlord/api/IMaterialsManager.java
@@ -1,6 +1,7 @@
 package biz.princeps.landlord.api;
 
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.UUID;
@@ -27,5 +28,22 @@ public interface IMaterialsManager {
     Material getFireCharge();
 
     ItemStack getGreyStainedGlass();
+
+    Material getNetherGrass();
+
+    Material getEnderGrass();
+
+    default Material getWorldGrass(World world) {
+        switch (world.getEnvironment()) {
+            case NORMAL:
+                return getGrass();
+            case NETHER:
+                return getNetherGrass();
+            case THE_END:
+                return getEnderGrass();
+            default:
+                return Material.BARRIER;
+        }
+    }
 
 }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/Landlordbase.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/Landlordbase.java
@@ -142,8 +142,7 @@ public class Landlordbase extends MainCommand {
                         if (Options.enabled_map()) {
                             tabReturn.add(subCommand.getName());
                         }
-                    } else if (subCommand instanceof Shop || subCommand instanceof Claims
-                            || subCommand instanceof GiveClaims) {
+                    } else if (subCommand instanceof Shop || subCommand instanceof GiveClaims) {
                         if (Options.enabled_shop()) {
                             tabReturn.add(subCommand.getName());
                         }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/AdminTeleport.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/admin/AdminTeleport.java
@@ -58,7 +58,7 @@ public class AdminTeleport extends LandlordCommand {
                             lm.getRawString("Commands.AdminTp.guiHeader").replace("%player%", target));
 
                     for (IOwnedLand land : lands) {
-                        landGui.addIcon(new Icon(new ItemStack(plugin.getMaterialsManager().getGrass()))
+                        landGui.addIcon(new Icon(new ItemStack(plugin.getMaterialsManager().getWorldGrass(land.getWorld())))
                                 .setName(land.getName())
                                 .addClickAction((p) -> {
                                             Location toTp = land.getALocation();

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/ListLands.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/ListLands.java
@@ -137,7 +137,7 @@ public class ListLands extends LandlordCommand {
                             }
                         }
 
-                        Icon icon = new Icon(new ItemStack(plugin.getMaterialsManager().getGrass()));
+                        Icon icon = new Icon(new ItemStack(plugin.getMaterialsManager().getWorldGrass(land.getWorld())));
                         icon.setName(lm.getRawString("Commands.ListLands.gui.itemname")
                                 .replace("%name%", land.getName()));
                         icon.setLore(lore);

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/MultiListLands.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/MultiListLands.java
@@ -144,7 +144,7 @@ public class MultiListLands extends LandlordCommand {
                             }
                         }
 
-                        Icon icon = new Icon(new ItemStack(plugin.getMaterialsManager().getGrass()));
+                        Icon icon = new Icon(new ItemStack(plugin.getMaterialsManager().getWorldGrass(land.getWorld())));
                         icon.setName(lm.getRawString("Commands.MultiListLands.gui.itemname")
                                 .replace("%name%", land.getName()));
                         icon.setLore(lore);

--- a/LandLord-latest/src/main/java/biz/princeps/landlord/LLFlag.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/LLFlag.java
@@ -3,6 +3,7 @@ package biz.princeps.landlord;
 import biz.princeps.landlord.api.ILLFlag;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.RegionGroup;
+import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import org.bukkit.Material;
@@ -25,27 +26,25 @@ public class LLFlag implements ILLFlag {
         this.flag = flag;
         this.mat = mat;
 
-        RegionGroup regionGroupFlag = (RegionGroup) pr.getFlags().get(flag.getRegionGroupFlag());
+        RegionGroupFlag regionGroupFlag = flag.getRegionGroupFlag();
+        RegionGroup regionGroup = (RegionGroup) pr.getFlags().get(regionGroupFlag);
         StateFlag.State value = (StateFlag.State) pr.getFlags().get(flag);
-        setStatus(regionGroupFlag, value);
+        setStatus(regionGroup == null ? regionGroupFlag.getDefault() : regionGroup, value == null ? flag.getDefault() : value);
     }
 
-    void setStatus(RegionGroup grp, Object state) {
+    private void setStatus(RegionGroup grp, StateFlag.State state) {
         if (grp == RegionGroup.MEMBERS && state == StateFlag.State.ALLOW ||
                 grp == RegionGroup.NON_MEMBERS && state == StateFlag.State.DENY) {
             friendStatus = true;
             allStatus = false;
-            // System.out.println("10");
         }
         if (grp == RegionGroup.ALL && state == StateFlag.State.ALLOW) {
             friendStatus = true;
             allStatus = true;
-            // System.out.println("11");
         }
         if (grp == RegionGroup.NON_OWNERS && state == StateFlag.State.DENY) {
             friendStatus = false;
             allStatus = false;
-            // System.out.println("00");
         }
     }
 

--- a/LandLord-latest/src/main/java/biz/princeps/landlord/OwnedLand.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/OwnedLand.java
@@ -21,8 +21,10 @@ import org.bukkit.World;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Project: LandLord
@@ -30,6 +32,8 @@ import java.util.UUID;
  * Date: 06-05-19
  */
 public class OwnedLand extends AOwnedLand {
+
+    private static final Map<String, Flag<StateFlag.State>> FLAGS_CACHE = new ConcurrentHashMap<>();
 
     private final ProtectedRegion region;
     private final FlagRegistry flagRegistry = WorldGuard.getInstance().getFlagRegistry();
@@ -325,7 +329,7 @@ public class OwnedLand extends AOwnedLand {
     }
 
     private Flag<StateFlag.State> getWGFlag(String flagName) {
-        return (Flag<StateFlag.State>) Flags.fuzzyMatchFlag(flagRegistry, flagName);
+        return FLAGS_CACHE.computeIfAbsent(flagName, name -> (Flag<StateFlag.State>) Flags.fuzzyMatchFlag(flagRegistry, name));
     }
 
 }

--- a/LandLord-latest/src/main/java/biz/princeps/landlord/manager/MaterialsManager.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/manager/MaterialsManager.java
@@ -64,4 +64,14 @@ public class MaterialsManager implements IMaterialsManager {
     public ItemStack getGreyStainedGlass() {
         return new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
     }
+
+    @Override
+    public Material getNetherGrass() {
+        return Material.CRIMSON_NYLIUM;
+    }
+
+    @Override
+    public Material getEnderGrass() {
+        return Material.END_STONE;
+    }
 }

--- a/LandLord-legacy/src/main/java/biz/princeps/landlord/LLFlag.java
+++ b/LandLord-legacy/src/main/java/biz/princeps/landlord/LLFlag.java
@@ -3,6 +3,7 @@ package biz.princeps.landlord;
 import biz.princeps.landlord.api.ILLFlag;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.RegionGroup;
+import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import org.bukkit.Material;
@@ -25,27 +26,25 @@ public class LLFlag implements ILLFlag {
         this.flag = flag;
         this.mat = mat;
 
-        RegionGroup regionGroupFlag = (RegionGroup) pr.getFlags().get(flag.getRegionGroupFlag());
+        RegionGroupFlag regionGroupFlag = flag.getRegionGroupFlag();
+        RegionGroup regionGroup = (RegionGroup) pr.getFlags().get(regionGroupFlag);
         StateFlag.State value = (StateFlag.State) pr.getFlags().get(flag);
-        setStatus(regionGroupFlag, value);
+        setStatus(regionGroup == null ? regionGroupFlag.getDefault() : regionGroup, value == null ? flag.getDefault() : value);
     }
 
-    void setStatus(RegionGroup grp, Object state) {
+    private void setStatus(RegionGroup grp, StateFlag.State state) {
         if (grp == RegionGroup.MEMBERS && state == StateFlag.State.ALLOW ||
                 grp == RegionGroup.NON_MEMBERS && state == StateFlag.State.DENY) {
             friendStatus = true;
             allStatus = false;
-            // System.out.println("10");
         }
         if (grp == RegionGroup.ALL && state == StateFlag.State.ALLOW) {
             friendStatus = true;
             allStatus = true;
-            // System.out.println("11");
         }
         if (grp == RegionGroup.NON_OWNERS && state == StateFlag.State.DENY) {
             friendStatus = false;
             allStatus = false;
-            // System.out.println("00");
         }
     }
 

--- a/LandLord-legacy/src/main/java/biz/princeps/landlord/OwnedLand.java
+++ b/LandLord-legacy/src/main/java/biz/princeps/landlord/OwnedLand.java
@@ -21,8 +21,10 @@ import org.bukkit.entity.EntityType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Project: LandLord
@@ -30,6 +32,8 @@ import java.util.UUID;
  * Date: 06-05-19
  */
 public class OwnedLand extends AOwnedLand {
+
+    private static final Map<String, Flag<StateFlag.State>> FLAGS_CACHE = new ConcurrentHashMap<>();
 
     private final ProtectedRegion region;
     private final FlagRegistry flagRegistry = WorldGuardPlugin.inst().getFlagRegistry();
@@ -325,7 +329,7 @@ public class OwnedLand extends AOwnedLand {
     }
 
     private Flag<StateFlag.State> getWGFlag(String flagName) {
-        return (Flag<StateFlag.State>) DefaultFlag.fuzzyMatchFlag(flagRegistry, flagName);
+        return FLAGS_CACHE.computeIfAbsent(flagName, name -> (Flag<StateFlag.State>) DefaultFlag.fuzzyMatchFlag(flagRegistry, name));
     }
 
 }

--- a/LandLord-legacy/src/main/java/biz/princeps/landlord/manager/MaterialsManager.java
+++ b/LandLord-legacy/src/main/java/biz/princeps/landlord/manager/MaterialsManager.java
@@ -65,5 +65,13 @@ public class MaterialsManager implements IMaterialsManager {
         return new ItemStack(Material.STAINED_GLASS_PANE, 1, (short) 7);
     }
 
+    @Override
+    public Material getNetherGrass() {
+        return Material.NETHERRACK;
+    }
 
+    @Override
+    public Material getEnderGrass() {
+        return Material.ENDER_STONE;
+    }
 }


### PR DESCRIPTION
- Maintains a Map to fetch more efficiently flags from their id.
- Seperates lands' icon in lists according to their dimension _(somehow breaking for older versions, configurable items is a TODO, I kept the things simple)_.
- Fix default flag value visibility with non-registered flags in a land. For example, when a custom flag is added to the plugin, lands claimed before this addition do not have the flag registered until a modification is done with the ``/land manage`. However, it's real default value must be shown (~allowed).
- Removes some useless debug comments.