### PR TITLE
Fix spawn flag save issue

### DIFF
--- a/LandLord-latest/src/main/java/biz/princeps/landlord/OwnedLand.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/OwnedLand.java
@@ -197,6 +197,9 @@ public class OwnedLand extends AOwnedLand {
         } else {
             flag.add(EntityType.REGISTRY.get(mob.getName().toLowerCase()));
         }
+        // Mark region as dirty to make the change persistent into WorldGuard data.
+        // Simple additions or removal to flag lists do not mark the region as dirty ~ to be saved.
+        region.setDirty(true);
     }
 
     @Override

--- a/LandLord-legacy/src/main/java/biz/princeps/landlord/OwnedLand.java
+++ b/LandLord-legacy/src/main/java/biz/princeps/landlord/OwnedLand.java
@@ -197,6 +197,9 @@ public class OwnedLand extends AOwnedLand {
         } else {
             flag.add(mob.getType());
         }
+        // Mark region as dirty to make the change persistent into WorldGuard data.
+        // Simple additions or removal to flag lists do not mark the region as dirty ~ to be saved.
+        region.setDirty(true);
     }
 
     @Override


### PR DESCRIPTION
_not a major point although a server constantly restarts)_

- Mark region as dirty to make the change persistent into WorldGuard data. Simple additions or removal to flag lists do not mark the region as dirty ~ to be saved.