### PR TITLE
style: fix Bad Smells in biz.princeps.lib.command.SubCommand

### DIFF
--- a/LandLord-core/src/main/java/biz/princeps/lib/command/SubCommand.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/command/SubCommand.java
@@ -19,7 +19,7 @@ public abstract class SubCommand implements Command {
     private final String usage;
     private final Set<String> aliases;
 
-    public SubCommand(String name, String usage, Set<String> permissions, Set<String> aliases) {
+    protected SubCommand(String name, String usage, Set<String> permissions, Set<String> aliases) {
         this.name = name;
         this.usage = usage;
         this.aliases = aliases;
@@ -75,7 +75,7 @@ public abstract class SubCommand implements Command {
      * @return whether the cs is allowed to execute the cmd or not
      */
     public boolean hasPermission(CommandSender cs) {
-        if (permissions.size() == 0) {
+        if (permissions.isEmpty()) {
             return true;
         }
 


### PR DESCRIPTION
# Repairing Code Style Issues
## SizeReplaceableByIsEmpty
Checking if a something is empty should be done by `Object#isEmpty` instead of `Object.size==0`
## Non-Protected-Constructor-in-Abstract-Class
A non-protected constructor in an abstract class is not needed because only subclasses can be instantiated
## Changes: 
* Replaced collection.size empty check with collection.isEmpty
<!-- fingerprint:1289767823 -->
* Constructor `biz.princeps.lib.command.SubCommand(java.lang.String,java.lang.String,java.util.Set,java.util.Set)` is now protected instead of public
<!-- fingerprint:817702990 -->
