### PR TITLE
style: fix Bad Smells in biz.princeps.landlord.OwnedLand

### DIFF
--- a/LandLord-latest/src/main/java/biz/princeps/landlord/OwnedLand.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/OwnedLand.java
@@ -55,7 +55,7 @@ public class OwnedLand extends AOwnedLand {
         this(plugin, region);
 
         // Insert default flags.
-        if (region.getFlags().size() == 0) {
+        if (region.getFlags().isEmpty()) {
             initFlags(owner);
             initRegionPriority();
         }


### PR DESCRIPTION
# Repairing Code Style Issues
## SizeReplaceableByIsEmpty
Checking if a something is empty should be done by `Object#isEmpty` instead of `Object.size==0`
## Changes: 
* Replaced collection.size empty check with collection.isEmpty
<!-- ruleID: "SizeReplaceableByIsEmpty"
filePath: "LandLord-latest/src/main/java/biz/princeps/landlord/OwnedLand.java"
position:
  startLine: 58
  endLine: 0
  startColumn: 13
  endColumn: 0
  charOffset: 2025
  charLength: 29
message: "'region.getFlags().size() == 0' can be replaced with 'region.getFlags().isEmpty()'"
messageMarkdown: "`region.getFlags().size() == 0` can be replaced with 'region.getFlags().isEmpty()'"
snippet: "\n        // Insert default flags.\n        if (region.getFlags().size()\
  \ == 0) {\n            initFlags(owner);\n            initRegionPriority();"
analyzer: "Qodana"
 -->
<!-- fingerprint:1063334509 -->
