### PR TITLE
style: fix Bad Smells in biz.princeps.landlord.protection.AOwnedLand

### DIFF
--- a/LandLord-core/src/main/java/biz/princeps/landlord/protection/AOwnedLand.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/protection/AOwnedLand.java
@@ -29,7 +29,7 @@ public abstract class AOwnedLand implements IOwnedLand {
     protected final int chunkX;
     protected final int chunkZ;
 
-    public AOwnedLand(ILandLord plugin, World world, String name) {
+    protected AOwnedLand(ILandLord plugin, World world, String name) {
         this.plugin = plugin;
         this.world = world;
         this.name = name;


### PR DESCRIPTION
# Repairing Code Style Issues
## Non-Protected-Constructor-in-Abstract-Class
A non-protected constructor in an abstract class is not needed because only subclasses can be instantiated
## Changes: 
* Constructor `biz.princeps.landlord.protection.AOwnedLand(biz.princeps.landlord.api.ILandLord,org.bukkit.World,java.lang.String)` is now protected instead of public
<!-- ruleID: "NonProtectedConstructorInAbstractClass"
filePath: "LandLord-core/src/main/java/biz/princeps/landlord/protection/AOwnedLand.java"
position:
  startLine: 32
  endLine: 0
  startColumn: 12
  endColumn: 0
  charOffset: 805
  charLength: 10
message: "Constructor 'AOwnedLand()' of an abstract class should not be declared 'public'"
messageMarkdown: "Constructor `AOwnedLand()` of an abstract class should not be declared\
  \ 'public'"
snippet: "    protected final int chunkZ;\n\n    public AOwnedLand(ILandLord plugin,\
  \ World world, String name) {\n        this.plugin = plugin;\n        this.world\
  \ = world;"
analyzer: "Qodana"
 -->
<!-- fingerprint:1596056006 -->
