### PR TITLE
fix Bad Smells in biz.princeps.landlord.commands.management.MultiListLands

### DIFF
--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/MultiListLands.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/MultiListLands.java
@@ -98,7 +98,7 @@ public class MultiListLands extends LandlordCommand {
             public void run() {
                 List<IOwnedLand> lands = new ArrayList<>(mode.getLandsOf(radius, sender.getLocation(), target.getUuid(), wg));
 
-                if (lands.size() == 0) {
+                if (lands.isEmpty()) {
                     lm.sendMessage(sender, plugin.getLangManager().getString("Commands.MultiListLands.noLands"));
                     return;
                 }


### PR DESCRIPTION
# Repairing Code Style Issues
## SizeReplaceableByIsEmpty
Checking if a something is empty should be done by `Object#isEmpty` instead of `Object.size==0`
## Changes: 
* Replaced collection.size empty check with collection.isEmpty
<!-- ruleID: "SizeReplaceableByIsEmpty"
filePath: "LandLord-core/src/main/java/biz/princeps/landlord/commands/management/MultiListLands.java"
position:
  startLine: 101
  endLine: 0
  startColumn: 21
  endColumn: 0
  charOffset: 4141
  charLength: 17
message: "'lands.size() == 0' can be replaced with 'lands.isEmpty()'"
messageMarkdown: "`lands.size() == 0` can be replaced with 'lands.isEmpty()'"
snippet: "                List<IOwnedLand> lands = new ArrayList<>(mode.getLandsOf(radius,\
  \ sender.getLocation(), target.getUuid(), wg));\n\n                if (lands.size()\
  \ == 0) {\n                    lm.sendMessage(sender, plugin.getLangManager().getString(\"\
  Commands.MultiListLands.noLands\"));\n                    return;"
analyzer: "Qodana"
 -->
<!-- fingerprint:72394350 -->
