### PR TITLE
style: fix SizeReplaceableByIsEmpty in multiple files

### DIFF
--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/claiming/MultiClaim.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/claiming/MultiClaim.java
@@ -83,7 +83,7 @@ public class MultiClaim extends LandlordCommand {
         }
 
         Set<Chunk> toClaim = mode.getFreeLands(radius, player.getLocation(), wg);
-        if (toClaim.size() == 0) {
+        if (toClaim.isEmpty()) {
             lm.sendMessage(player, lm.getString(player, "Commands.MultiClaim.noLands"));
             return;
         }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/ListLands.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/ListLands.java
@@ -91,7 +91,7 @@ public class ListLands extends LandlordCommand {
             public void run() {
                 List<IOwnedLand> lands = new ArrayList<>(plugin.getWGManager().getRegions(target.getUuid()));
 
-                if (lands.size() == 0) {
+                if (lands.isEmpty()) {
                     lm.sendMessage(sender, plugin.getLangManager().getString("Commands.ListLands.noLands"));
                     return;
                 }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Manage.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Manage.java
@@ -132,7 +132,7 @@ public class Manage extends LandlordCommand {
 
 
     private void setGreet(Player player, String[] args, List<IOwnedLand> lands, int casy) {
-        if (lands.size() == 0 || lands.get(0) == null) {
+        if (lands.isEmpty() || lands.get(0) == null) {
             lm.sendMessage(player, lm.getString(player, "Commands.Manage.notOwnFreeLand"));
             return;
         }
@@ -161,7 +161,7 @@ public class Manage extends LandlordCommand {
     }
 
     private void setFarewell(Player player, String[] args, List<IOwnedLand> lands, int casy) {
-        if (lands.size() == 0 || lands.get(0) == null) {
+        if (lands.isEmpty() || lands.get(0) == null) {
             lm.sendMessage(player, lm.getString(player, "Commands.Manage.notOwnFreeLand"));
             return;
         }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/ManageAll.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/ManageAll.java
@@ -39,7 +39,7 @@ public class ManageAll extends LandlordCommand {
 
         List<IOwnedLand> lands = Lists.newArrayList(plugin.getWGManager().getRegions(player.getUniqueId()));
 
-        if (lands.size() == 0) {
+        if (lands.isEmpty()) {
             lm.sendMessage(player, plugin.getLangManager().getString("Commands.ListLands.noLands"));
             return;
         }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/MultiManage.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/MultiManage.java
@@ -52,7 +52,7 @@ public class MultiManage extends LandlordCommand {
 
         List<IOwnedLand> lands = new ArrayList<>(mode.getLandsOf(radius, player.getLocation(), player.getUniqueId(), wg));
 
-        if (lands.size() == 0) {
+        if (lands.isEmpty()) {
             lm.sendMessage(player, plugin.getLangManager().getString("Commands.ListLands.noLands"));
             return;
         }

--- a/LandLord-core/src/main/java/biz/princeps/lib/command/MainCommand.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/command/MainCommand.java
@@ -97,7 +97,7 @@ public abstract class MainCommand extends BukkitCommand implements Command {
      * @return whether the cs is allowed to execute the cmd or not
      */
     public boolean hasPermission(CommandSender cs) {
-        if (permissions.size() == 0) {
+        if (permissions.isEmpty()) {
             return true;
         }
 


### PR DESCRIPTION
This PR fixes some style issues in the landlord-core package.
# Repairing Code Style Issues
## SizeReplaceableByIsEmpty
Checking if a something is empty should be done by `Object#isEmpty` instead of `Object.size==0`
# Repairing Code Style Issues
* SizeReplaceableByIsEmpty (7)