### PR TITLE
Revert "refactor: refactor bad smell InnerClassMayBeStatic"

### DIFF
--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/Landlordbase.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/Landlordbase.java
@@ -293,7 +293,7 @@ public class Landlordbase extends MainCommand {
         plugin.getUtilsManager().sendBasecomponent(properties.getPlayer(), msg.create());
     }
 
-    public static class Confirm extends SubCommand {
+    public class Confirm extends SubCommand {
 
         public Confirm() {
             super("confirm",

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/Landlordbase.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/Landlordbase.java
@@ -293,7 +293,11 @@ public class Landlordbase extends MainCommand {
         plugin.getUtilsManager().sendBasecomponent(properties.getPlayer(), msg.create());
     }
 
+    @SuppressWarnings({"synthetic-access", "InnerClassMayBeStatic"})
     public class Confirm extends SubCommand {
+        /**
+         * This class MUST NOT be static due to how commands are registered, see {@link MainCommand}.
+         */
 
         public Confirm() {
             super("confirm",
@@ -308,7 +312,11 @@ public class Landlordbase extends MainCommand {
         }
     }
 
+    @SuppressWarnings({"synthetic-access", "InnerClassMayBeStatic"})
     public class Version extends SubCommand {
+        /**
+         * This class MUST NOT be static due to how commands are registered, see {@link MainCommand}.
+         */
 
         public Version() {
             super("version",


### PR DESCRIPTION
Reverts LandlordPlugin/LandLord#144

> This is incorrect! It causes problems during command registration, see here https://github.com/LandlordPlugin/LandLord/blob/development/LandLord-core/src/main/java/biz/princeps/lib/command/MainCommand.java#L48.

```java
02.03 04:06:20 [Server] [INFO] [Landlord] Enabling Landlord v5.0.0-DEV+fa48a86
02.03 04:06:20 [Server] [INFO] [WorldGuard] Registering session handler biz.princeps.landlord.LandSessionHandler
02.03 04:06:20 [Server] [WARN] [WorldGuard] Someone is unregistering a default WorldGuard handler: com.sk89q.worldguard.session.handler.GreetingFlag. This may cause parts of WorldGuard to stop functioning
02.03 04:06:20 [Server] [WARN] [WorldGuard] Someone is unregistering a default WorldGuard handler: com.sk89q.worldguard.session.handler.FarewellFlag. This may cause parts of WorldGuard to stop functioning
02.03 04:06:20 [Server] [INFO] [PlaceholderAPI] Successfully registered expansion: landlord [5.0.0-DEV+fa48a86]
02.03 04:06:20 [Server] [INFO] [Landlord] ยง2Metrics enabled. Thank you :3
02.03 04:06:20 [Server] [ERROR] Error occurred while enabling Landlord v5.0.0-DEV+fa48a86 (Is it up to date?)
02.03 04:06:20 [Server] [INFO] java.lang.IllegalArgumentException: wrong number of arguments
02.03 04:06:20 [Server] [INFO] at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
02.03 04:06:20 [Server] [INFO] at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:78) ~[?:?]
02.03 04:06:20 [Server] [INFO] at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
02.03 04:06:20 [Server] [INFO] at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[?:?]
02.03 04:06:20 [Server] [INFO] at java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[?:?]
02.03 04:06:20 [Server] [INFO] at biz.princeps.lib.command.MainCommand.<init>(MainCommand.java:48) ~[landlord-latest-5.0.0-DEV-all.jar:?]
02.03 04:06:20 [Server] [INFO] at biz.princeps.landlord.commands.Landlordbase.<init>(Landlordbase.java:75) ~[landlord-latest-5.0.0-DEV-all.jar:?]
02.03 04:06:20 [Server] [INFO] at biz.princeps.landlord.ALandLord.postloadPrincepsLib(ALandLord.java:184) ~[landlord-latest-5.0.0-DEV-all.jar:?]
02.03 04:06:20 [Server] [INFO] at biz.princeps.landlord.ALandLord.onEnable(ALandLord.java:93) ~[landlord-latest-5.0.0-DEV-all.jar:?]
02.03 04:06:20 [Server] [INFO] at biz.princeps.landlord.LandLord.onEnable(LandLord.java:59) ~[landlord-latest-5.0.0-DEV-all.jar:?]
02.03 04:06:20 [Server] [INFO] at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:279) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
02.03 04:06:20 [Server] [INFO] at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:192) ~[paper-1.19.3.jar:git-Paper-"e574412"]
02.03 04:06:20 [Server] [INFO] at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:104) ~[paper-1.19.3.jar:git-Paper-"e574412"]
02.03 04:06:20 [Server] [INFO] at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:507) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
02.03 04:06:20 [Server] [INFO] at org.bukkit.craftbukkit.v1_19_R2.CraftServer.enablePlugin(CraftServer.java:560) ~[paper-1.19.3.jar:git-Paper-"e574412"]
02.03 04:06:20 [Server] [INFO] at org.bukkit.craftbukkit.v1_19_R2.CraftServer.enablePlugins(CraftServer.java:471) ~[paper-1.19.3.jar:git-Paper-"e574412"]
02.03 04:06:20 [Server] [INFO] at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:635) ~[paper-1.19.3.jar:git-Paper-"e574412"]
02.03 04:06:20 [Server] [INFO] at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:434) ~[paper-1.19.3.jar:git-Paper-"e574412"]
02.03 04:06:20 [Server] [INFO] at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:308) ~[paper-1.19.3.jar:git-Paper-"e574412"]
02.03 04:06:20 [Server] [INFO] at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1101) ~[paper-1.19.3.jar:git-Paper-"e574412"]
02.03 04:06:20 [Server] [INFO] at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[paper-1.19.3.jar:git-Paper-"e574412"]
02.03 04:06:20 [Server] [INFO] at java.lang.Thread.run(Thread.java:831) ~[?:?]
```