### PR TITLE
[Legacy] Fix version detection

### DIFF
--- a/LandLord-core/src/main/java/biz/princeps/lib/crossversion/CrossVersion.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/crossversion/CrossVersion.java
@@ -15,7 +15,7 @@ public class CrossVersion {
     }
 
     public static String getVersion() {
-        return Bukkit.getServer().getClass().getPackage().getName().replace(".", ",").split(",")[3];
+        return Bukkit.getBukkitVersion().split("-")[0];
     }
 
     public ItemStack addNBTTag(ItemStack stack, String key, Object value) {

--- a/LandLord-core/src/main/java/biz/princeps/lib/crossversion/MaterialProxy.java
+++ b/LandLord-core/src/main/java/biz/princeps/lib/crossversion/MaterialProxy.java
@@ -21,8 +21,8 @@ public enum MaterialProxy {
 
     public ItemStack crossVersion() {
         String version = CrossVersion.getVersion();
-        if ("v1_12_R1".equals(version)) {
-            return getLegacy();
+        if (version.startsWith("1.12")) {
+            getLegacy();
         }
         return getLatest();
     }


### PR DESCRIPTION
- Paper remapping causes cross version detection to fail.
- Fallback on former Bukkit method to obtain the server minecraft version.