### PR TITLE
Use Glare's repo instead of jitpack for Towny

### DIFF
--- a/LandLord-core/build.gradle.kts
+++ b/LandLord-core/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     compileOnly("org.spigotmc:spigot-api:1.12.2-R0.1-SNAPSHOT")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
     compileOnly("me.clip:placeholderapi:2.11.5")
-    compileOnly("com.github.TownyAdvanced:Towny:0.100.1.7")
+    compileOnly("com.palmergames.bukkit.towny:towny:0.100.3.0")
     compileOnly("net.luckperms:api:5.4")
     compileOnly("com.mojang:authlib:1.5.25")
 }

--- a/buildSrc/src/main/kotlin/biz.princeps.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/biz.princeps.java-conventions.gradle.kts
@@ -14,6 +14,8 @@ repositories {
     // WorldEdit & WorldGuard
     maven { url = uri("https://maven.enginehub.org/repo/") }
     // Towny
+    maven { url = uri("https://repo.glaremasters.me/repository/towny/") }
+    // Vault API
     maven { url = uri("https://jitpack.io") }
     // PAPI
     maven { url = uri("https://repo.extendedclip.com/content/repositories/placeholderapi/") }


### PR DESCRIPTION
Jitpack is rather unreliable, causing build failures. Let's try to avoid it where possible.