### PR TITLE
Improve chunk regeneration performance

### DIFF
--- a/LandLord-api/src/main/java/biz/princeps/landlord/api/IRegenerationManager.java
+++ b/LandLord-api/src/main/java/biz/princeps/landlord/api/IRegenerationManager.java
@@ -3,6 +3,8 @@ package biz.princeps.landlord.api;
 import org.bukkit.Location;
 import org.bukkit.World;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface IRegenerationManager {
 
     /**
@@ -21,5 +23,16 @@ public interface IRegenerationManager {
      */
     default void regenerateChunk(Location location) {
         regenerateChunk(location.getWorld(), location.getBlockX() >> 4, location.getBlockZ() >> 4);
+    }
+
+    /**
+     * Regenerates all chunks of the given lands. All lands must belong to the same world.
+     *
+     * @param lands a non-empty iterable of lands to regenerate.
+     * @return a future that completes when all given chunks are regenerated.
+     */
+    default CompletableFuture<Void> regenerateChunks(Iterable<IOwnedLand> lands) {
+        lands.forEach(l -> regenerateChunk(l.getALocation()));
+        return CompletableFuture.completedFuture(null);
     }
 }

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/claiming/Unclaim.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/claiming/Unclaim.java
@@ -16,6 +16,8 @@ import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.entity.Player;
 
+import java.util.List;
+
 /**
  * Project: LandLord
  * Created by Alex D. (SpatiumPrinceps)
@@ -125,7 +127,7 @@ public class Unclaim extends LandlordCommand {
         wg.unclaim(ol.getWorld(), ol.getName());
 
         if (plugin.getConfig().getBoolean("CommandSettings.Unclaim.regenerate")) {
-            plugin.getRegenerationManager().regenerateChunk(ol.getALocation());
+            plugin.getRegenerationManager().regenerateChunks(List.of(ol));
         }
 
         // remove possible homes

--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Regenerate.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/management/Regenerate.java
@@ -10,8 +10,11 @@ import biz.princeps.lib.command.Arguments;
 import biz.princeps.lib.command.Properties;
 import biz.princeps.lib.gui.ConfirmationGUI;
 import com.google.common.collect.Sets;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.List;
 
 
 /**
@@ -83,10 +86,12 @@ public class Regenerate extends LandlordCommand {
                                 }
                             }.runTask(plugin);
 
-                            plugin.getRegenerationManager().regenerateChunk(finalLand.getALocation());
-                            lm.sendMessage(player, lm.getString(player, "Commands.Regenerate.success")
-                                    .replace("%land%", finalLand.getName()));
-                            player.closeInventory();
+                            plugin.getRegenerationManager().regenerateChunks(List.of(finalLand))
+                                    .whenCompleteAsync((v, e) -> {
+                                        lm.sendMessage(player, lm.getString(player, "Commands.Regenerate.success")
+                                            .replace("%land%", finalLand.getName()));
+                                        player.closeInventory();
+                                    }, r -> Bukkit.getScheduler().runTask(plugin, r));
                         }
 
                     }, (p2) -> lm.sendMessage(player, lm.getString(player, "Commands.Regenerate.abort")

--- a/LandLord-core/src/main/java/biz/princeps/landlord/multi/MultiUnclaimTask.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/multi/MultiUnclaimTask.java
@@ -14,7 +14,9 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 public class MultiUnclaimTask extends AMultiTask<IOwnedLand> {
 
@@ -28,6 +30,7 @@ public class MultiUnclaimTask extends AMultiTask<IOwnedLand> {
     private final World world;
     private final ManageMode manageMode;
     private double totalPayBack;
+    private final List<IOwnedLand> delayedRegenerations;
 
     public MultiUnclaimTask(ILandLord plugin, Player player, Collection<IOwnedLand> operations, World world, ManageMode manageMode) {
         super(plugin, operations);
@@ -42,6 +45,7 @@ public class MultiUnclaimTask extends AMultiTask<IOwnedLand> {
         this.world = world;
         this.manageMode = manageMode;
         this.totalPayBack = 0;
+        this.delayedRegenerations = new ArrayList<>();
     }
 
     @Override
@@ -68,10 +72,9 @@ public class MultiUnclaimTask extends AMultiTask<IOwnedLand> {
                 totalPayBack += payback;
             }
 
-            Location location = ownedLand.getALocation();
             wgManager.unclaim(ownedLand.getWorld(), ownedLand.getName());
             if (plugin.getConfig().getBoolean("CommandSettings.Unclaim.regenerate", false)) {
-                plugin.getRegenerationManager().regenerateChunk(location);
+                delayedRegenerations.add(ownedLand);
             }
 
             // remove possible homes
@@ -108,6 +111,10 @@ public class MultiUnclaimTask extends AMultiTask<IOwnedLand> {
                         .replace("%world%", world.getName())
                         .replace("%money%", (Options.isVaultEnabled() ? plugin.getVaultManager().format(totalPayBack) : "-eco disabled-")));
                 break;
+        }
+
+        if (!delayedRegenerations.isEmpty()) {
+            plugin.getRegenerationManager().regenerateChunks(delayedRegenerations);
         }
 
         new BukkitRunnable() {

--- a/LandLord-latest/src/main/java/biz/princeps/landlord/regenerators/RegenerationManager.java
+++ b/LandLord-latest/src/main/java/biz/princeps/landlord/regenerators/RegenerationManager.java
@@ -1,24 +1,72 @@
 package biz.princeps.landlord.regenerators;
 
+import biz.princeps.landlord.LandLord;
+import biz.princeps.landlord.api.IOwnedLand;
 import biz.princeps.landlord.api.IRegenerationManager;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Region;
+import com.sk89q.worldedit.regions.RegionIntersection;
 import org.bukkit.World;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
 public class RegenerationManager implements IRegenerationManager {
 
     @Override
     public void regenerateChunk(World world, int x, int z) {
         com.sk89q.worldedit.world.World weWorld = BukkitAdapter.adapt(world);
-        Region region = new CuboidRegion(BlockVector3.at(x << 4, weWorld.getMinY(), z << 4),
-                BlockVector3.at((x << 4) + 15, weWorld.getMaxY(), (z << 4) + 15));
+        Region region = regionForChunk(x, z, weWorld.getMinY(), weWorld.getMaxY());
         WorldEdit worldEdit = WorldEdit.getInstance();
         EditSession editSession = worldEdit.getEditSessionFactory().getEditSession(weWorld, -1);
         weWorld.regenerate(region, editSession);
         editSession.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> regenerateChunks(Iterable<IOwnedLand> lands) {
+        List<Region> regions = new ArrayList<>();
+        World world = null;
+        for (IOwnedLand land : lands) {
+            if (world == null) {
+                world = land.getWorld();
+            } else if (!world.equals(land.getWorld())) {
+                return CompletableFuture.failedFuture(new IllegalArgumentException("Lands from different worlds"));
+            }
+            regions.add(regionForChunk(land.getChunkX(), land.getChunkZ(), world.getMinHeight(), world.getMaxHeight()));
+        }
+        RegionIntersection intersection = new RegionIntersection(regions);
+        com.sk89q.worldedit.world.World weWorld = BukkitAdapter.adapt(world);
+        if (isFawe()) {
+            return CompletableFuture.runAsync(() -> regenerate(weWorld, intersection))
+                .exceptionally(ex -> {
+                    LandLord.getPlugin(LandLord.class).getLogger().log(Level.SEVERE, "failed to regenerate chunks", ex);
+                    return null;
+                });
+        }
+        regenerate(weWorld, intersection);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private static boolean isFawe() {
+        return WorldEditPlugin.getPlugin(WorldEditPlugin.class).getName().equals("FastAsyncWorldEdit");
+    }
+
+    private static void regenerate(com.sk89q.worldedit.world.World weWorld, RegionIntersection intersection) {
+        try (EditSession es = WorldEdit.getInstance().newEditSession(weWorld)) {
+            weWorld.regenerate(intersection, es);
+        }
+    }
+
+    private static CuboidRegion regionForChunk(int x, int z, int minY, int maxY) {
+        return new CuboidRegion(BlockVector3.at(x << 4, minY, z << 4),
+            BlockVector3.at((x << 4) + 15, maxY, (z << 4) + 15));
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,14 +18,14 @@ subprojects {
 
 tasks {
     register<RunServer>("runLatest") {
-        minecraftVersion("1.21.1")
+        minecraftVersion("1.21.4")
         pluginJars(*project(":LandLord-latest").getTasksByName("shadowJar", false).map { (it as Jar).archiveFile }
             .toTypedArray())
         downloadPlugins {
-            modrinth("worldguard", "7.0.12")
+            modrinth("worldguard", "f9NoeotB") // 7.0.13
             // worldedit supports multiple platforms, we need to use the specific version id
             // instead of the actual version
-            modrinth("worldedit", "ecqqLKUO") // 7.3.8
+            modrinth("fastasyncworldedit", "cf5QSDJ7") // 2.12.3 Paper
         }
         runDirectory = file("run/latest")
         group = "run paper"

--- a/buildSrc/src/main/kotlin/biz.princeps.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/biz.princeps.java-conventions.gradle.kts
@@ -10,7 +10,7 @@ repositories {
     mavenCentral()
     // Spigot & Paper
     maven { url = uri("https://hub.spigotmc.org/nexus/content/repositories/snapshots/") }
-    maven { url = uri("https://papermc.io/repo/repository/maven-public/") }
+    maven { url = uri("https://repo.papermc.io/repository/maven-public/") }
     // WorldEdit & WorldGuard
     maven { url = uri("https://maven.enginehub.org/repo/") }
     // Towny


### PR DESCRIPTION
Especially when regenerating multiple chunks, the approach to do so one-by-one causes significant overhead. We can combine such situations and also regenerate chunks async when using FAWE.